### PR TITLE
CASH-1660 Announced removal of payment provider ID and paytype ID in changelog

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -2440,8 +2440,6 @@ components:
           - 99
           - 101
         payment:
-          provider: 7
-          method: 12
           gateway_name: "basic"
           method_name: "advance"
         payment_status: captured
@@ -2607,8 +2605,8 @@ components:
         business_model: B2C
         offline_location_id: 7127e08a-4af0-4fdf-ac7b-157be3345df0
         payment:
-          provider: 7
-          method: 12
+          gateway_name: mollie
+          method_name: ideal
           status:
             id: 1
         debtor:

--- a/web/swagger-docs/changelog.md
+++ b/web/swagger-docs/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2.2.2] & [1.3.2] 2020-10-27
+
+### Added
+* Added __getGateways__ and __getStoreGateways__ operations for retrieving available payment
+ gateways and methods. These deprecate the __getPayTypes__ and __getPayTypesPerStore__ operations
+  respectively, which will be removed on the 1st of February 2021.
+
+### Changed
+* __OrderPayment__._provider_ and __OrderPayment__._method_ are now deprecated and will be
+ removed on the 1st of February 2021. These fields have been replaced with __OrderPayment__
+ ._gateway_name_ and __OrderPayment__._method_name_ respectively.  
+
 ## [2.2.1] & [1.3.1] 2019-11-27
 
 ### Changed


### PR DESCRIPTION
Also removed ID usages from examples, but left the core definitions in place .