### PR TITLE
BIER-2439 update documentation and changelog

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1705,7 +1705,9 @@ components:
           default: 12.5
           action: 9.95
         created_date: "2016-07-04"
+        created_time: "09:11:25"
         updated_date: "2016-07-25"
+        updated_time: "11:16:59"
         stock: 15
         delivery_days: 5
         meta_title: "Funny shop: Funny Cushion"
@@ -1758,10 +1760,18 @@ components:
               description: Creation date
               type: string
               format: date
+            created_time:
+              description: Creation time
+              type: string
+              format: time
             updated_date:
               description: Last updated date
               type: string
               format: date
+            updated_time:
+              description: Last updated time
+              type: string
+              format: time
             can_backorder:
               description: Available for purchase if sold out (see also delivery_days)
               type: boolean

--- a/web/swagger-docs/changelog.md
+++ b/web/swagger-docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.2.4] & [1.3.4] 2020-11-16
+
+### Added
+* Added `created_time` to __Article__ entity.
+* Added `updated_time` to __Article__ entity.
+
 ## [2.2.3] & [1.3.3] 2020-11-11
 
 ### Changed


### PR DESCRIPTION
### This PR:
Reflects changes made in https://github.com/MyOnlineStore/myonlinestore/pull/7677

##### Summary
- [X] Appropriate documentation has been written (check if not applicable).

**Breaking changes** 🔥
- None

**Backwards compatible additions** ✨
- None

**Bugfixes/Changed internals** 🎈
- Add `created_time` and `updated_time` fields to `Article` entity