### PR TITLE
BIER-1330 remove `avatar_url` from the public API OR return empty string

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -3348,9 +3348,6 @@ components:
         open:
           description: Store is open for visitors
           type: boolean
-        avatar_url:
-          description: Url for the store avatar image (deprecated)
-          type: string
         version:
           description: Store subscription type
           type: string
@@ -3387,7 +3384,6 @@ components:
         primary_domain: https://www.knickknacks.be
         description: Nice stuff of very high quality
         open: true
-        avatar_url: https://static.mijnwebwinkel.nl/thumbs_stores/53747.jpg?1491382668
         version: Pro
         administration_language: nl_NL
         currency: EUR


### PR DESCRIPTION
### This PR:

- ‼️ Should not be merged before https://github.com/MyOnlineStore/myonlinestore/pull/8137 ‼️

##### Summary
- [x] Appropriate documentation has been written (check if not applicable).

**Breaking changes** 🔥
- Removed `avatar_url` from response in `/store` endpoint

**Backwards compatible additions** ✨
- None

**Bugfixes/Changed internals** 🎈
- None
