### PR TITLE
BIER-1330 Deprecate `tax` field in `article` endpoint(s)

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -2149,6 +2149,7 @@ components:
         tax:
           description: Vat percentage
           type: string
+          deprecated: true
         price:
           $ref: "#/components/schemas/ArticlePrice"
         stock:

--- a/web/swagger-docs/changelog.md
+++ b/web/swagger-docs/changelog.md
@@ -1,4 +1,7 @@
 # Changelog
+## [2.3.1] & [1.4.1] 2021-04-19
+* __Article__._tax_ is now deprecated. Expect this property to be removed in the future.
+
 ## [2.3] & [1.4] 2021-02-04
 * Removed payment endpoints that were deprecated in [2.2.2] and [1.3.2].
 * Removed __OrderPayment__ properties that were deprecated in [2.2.2] and [1.3.2].


### PR DESCRIPTION
### This PR:

##### Summary
- [X] Appropriate documentation has been written (check if not applicable).

**Breaking changes** 🔥
- None

**Backwards compatible additions** ✨
- None

**Bugfixes/Changed internals** 🎈
- Deprecated `Article`.`tax` field
