### PR TITLE
fix(BIER-3871): API / Adjust price description to match platform business rules

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -2445,10 +2445,10 @@ components:
     ArticlePrice:
       properties:
         default:
-          description: The default price for which the product is offered (incl. tax depending on the value of store.prices_include_tax)
+          description: The default price for which the product is offered (incl. tax depending on the value of [`store.prices_include_tax`](#tag/Store-information))
           type: string
         action:
-          description: The discounted price; overrides the default offer (incl. tax depending on the value of store.prices_include_tax)
+          description: The discounted price; overrides the default offer (incl. tax depending on the value of [`store.prices_include_tax`](#tag/Store-information))
           type: string
         purchase:
           description: The purchase price (excl. tax)


### PR DESCRIPTION
As per Bas' request, I applied formatting and added a link to the `Store` endpoint containing the referenced value.