### PR TITLE
fix(MOS-1500): Use Docker Compose V2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,24 +11,24 @@ endif
 initialize: generate-env pull install start
 
 install:
-	docker-compose run connect-documentation npm install ${ARGS}
+	docker compose run connect-documentation npm install ${ARGS}
 
 npm:
-	docker-compose exec connect-documentation npm ${ARGS}
+	docker compose exec connect-documentation npm ${ARGS}
 
 run:
-	docker-compose exec connect-documentation npm run ${ARGS}
+	docker compose exec connect-documentation npm run ${ARGS}
 
 pull:
-	docker-compose pull --parallel
+	docker compose pull --parallel
 
 restart: stop start
 
 start:
-	docker-compose up --build -d
+	docker compose up --build -d
 
 stop:
-	docker-compose stop -t1
+	docker compose stop -t1
 
 %:
 	@:


### PR DESCRIPTION
## Summary 🌟
Updates the Docker Compose V1 command invocations and references to V2 format.

## Testing instructions 📚
Verify that the adjusted `Makefile` actions still work as intended.