### PR TITLE
chore(MOS-1460): Deprecated numeric product ID

### DIFF
--- a/docker-compose.dist.yml
+++ b/docker-compose.dist.yml
@@ -19,5 +19,5 @@ services:
 
 networks:
   default:
-    external:
-      name: gateway
+    name: gateway
+    external: true

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -2246,8 +2246,11 @@ components:
         - $ref: "#/components/schemas/BaseArticle"
         - properties:
             id:
-              description: Internal article id
+              description: "Internal article ID (deprecated: use `uuid` instead)"
               type: integer
+              deprecated: true
+            uuid:
+              description: Article UUID
             created_date:
               description: Creation date
               type: string


### PR DESCRIPTION
## Summary
Deprecates the numeric product ID in favor of the product UUID.

## Technical notes
Also altered the external Docker gateway definition according to https://myonlinestore.atlassian.net/browse/MOS-1488.