### PR TITLE
chore: add SKU to Order Article response

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -3428,6 +3428,9 @@ components:
             description:
               description: Article description
               type: string
+            sku:
+              description: Article SKU
+              type: string
             price:
               type: object
               properties:


### PR DESCRIPTION
Our [current API documentation](https://connect.myonlinestore.com/#tag/Orders/operation/getOrders) does not show that the Order Articles response inside GET Orders does include the article's SKU, while in fact this is part of the response:
https://github.com/MyOnlineStore/myonlinestore/blob/fd743beaf4168dd1d2de2566a07fb1878154a1bf/component/api/src/Application/Format/OrderArticleArrayFormatter.php#L21
![Screenshot 2024-06-03 at 10 27 26](https://github.com/MyOnlineStore/public-api-docs/assets/21202865/d3a24923-143c-44aa-8789-9fae7cd5698e)


This PR adds it so the documentation is in line with the actual response.