### PR TITLE
chore(MOS-1718): Update documentation regarding article categories

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -229,7 +229,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ArticleChangeable"
+              $ref: "#/components/schemas/ArticlePatchable"
         description: Article with attributes to change
         required: true
       responses:
@@ -2201,8 +2201,8 @@ components:
           type: string
     Article:
       required:
-        - categories
         - name
+        - categories
       example:
         id: 123
         uuid: "095be615-a8ad-4c33-8e9c-c7612fbf6c9f"
@@ -2309,7 +2309,7 @@ components:
               type: array
               items:
                 $ref: "#/components/schemas/ArticleVariant"
-    ArticleChangeable:
+    ArticlePatchable:
       example:
         name: Funny cushion
         description: Endless fun
@@ -2335,6 +2335,10 @@ components:
           - category_id: 748020
             is_main: true
             is_active: true
+          - category_id: 824312
+            article_url_id: 4005
+            is_main: false
+            is_active: true
         lists:
           - id: 293822
             has_images: true
@@ -2359,6 +2363,10 @@ components:
       allOf:
         - $ref: "#/components/schemas/ArticlePostable"
         - properties:
+            categories:
+              type: array
+              items:
+                $ref: "#/components/schemas/CategoryArticlePatchable"
             variants:
               type: array
               items:
@@ -2413,7 +2421,7 @@ components:
             categories:
               type: array
               items:
-                $ref: "#/components/schemas/CategoryArticle"
+                $ref: "#/components/schemas/CategoryArticlePostable"
             lists:
               type: array
               items:
@@ -2752,14 +2760,25 @@ components:
         sorting:
           before: 78908
     CategoryArticle:
+      properties:
+        position:
+          description: Relative position of the article on the page
+          type: integer
+      allOf:
+        - $ref: "#/components/schemas/CategoryArticlePatchable"
+    CategoryArticlePatchable:
+      properties:
+        article_url_id:
+          description: Unique ID of the article linked to this page
+          type: integer
+      allOf:
+        - $ref: "#/components/schemas/CategoryArticlePostable"
+    CategoryArticlePostable:
       required:
         - category_id
       properties:
         category_id:
           description: Internal category id
-          type: integer
-        article_url_id:
-          description: Article page URL Id
           type: integer
         is_active:
           description: Whether the article is visible in the store on this page
@@ -2767,9 +2786,6 @@ components:
         is_main:
           description: Whether this is the primary category linked to the article
           type: boolean
-        position:
-          description: Relative position of the article on the page
-          type: integer
     CategorySorting:
       description: Category sorting details
       properties:


### PR DESCRIPTION
## Prerequisites
- [ ] https://github.com/MyOnlineStore/myonlinestore/pull/11498

## Summary
Updates the documentation to reflect the difference in `article.categories[]` properties, depending on the request method used:
- `POST`: `category_id`, `is_main`, `is_active` (each field speaks for itself)
- `PATCH`: + `article_url_id` (to update a specific existing link instead of re-adding)
- `GET`: + `position` (reflecting the current position on the page)