### PR TITLE
chore: Add test query param to get orders docs

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -826,6 +826,7 @@ paths:
         - $ref: "#/components/parameters/status_changed_end_date"
         - $ref: "#/components/parameters/debtor_email"
         - $ref: "#/components/parameters/debtor_id"
+        - $ref: "#/components/parameters/test"
         - name: ordering
           in: query
           description: Ordering (by ordernumber)
@@ -2136,6 +2137,14 @@ components:
         items:
           type: string
           format: uuid
+    test:
+      name: test
+      in: query
+      description: Include test orders in the response
+      required: false
+      schema:
+        type: boolean
+        default: false
   requestBodies:
     postArticleListsLists:
       content:


### PR DESCRIPTION
The `GET /orders` endpoint by default doesn't include test orders.
You can enable that by adding the `test=1` query param (defined [here](https://github.com/MyOnlineStore/myonlinestore/blob/4353eca0052ecafd3e679da37fb7caa53debe08d/src/Mww/Bundle/ApiBundle/Handler/OrderHandler.php#L408)) .

This PR adds that param to the docs.