### PR TITLE
chore: Add test query param to get order count docs

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -925,6 +925,7 @@ paths:
         - $ref: "#/components/parameters/status_id"
         - $ref: "#/components/parameters/status_changed_start_date"
         - $ref: "#/components/parameters/status_changed_end_date"
+        - $ref: "#/components/parameters/test"
       responses:
         "200":
           description: number of available orders


### PR DESCRIPTION
Also add the `test` param to the docs for the order count endpoint.

Merge this one first: https://github.com/MyOnlineStore/myonlinestore/pull/11646