### PR TITLE
chore(MOS-2091): Add basic page section request documentation.

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -36,7 +36,7 @@ info:
         
         If the B2B model applies to an order, some additional options are available:
         
-        * __Order__._reference_ may be set to an arbritary string
+        * __Order__._reference_ may be set to an arbitrary string
         * __OrderDebtor__._address_._invoice_._taxnumber_ may be set to a valid VAT number
           (this is not required, but recommended to allow the merchant to verify tax rule applicability)
         * Vat reverse charging becomes available as a valid tax strategy (see Tax rules section)
@@ -341,7 +341,7 @@ paths:
                         type: integer
                 -   name: visible
                     in: query
-                    description: Whether this field should be visibile or invisble to shop visitors
+                    description: Whether this field should be visible or invisible to shop visitors
                     required: true
                     schema:
                         type: boolean
@@ -386,7 +386,7 @@ paths:
                         type: integer
                 -   name: visible
                     in: query
-                    description: Whether this field should be visibile or invisble to shop visitors
+                    description: Whether this field should be visible or invisible to shop visitors
                     required: true
                     schema:
                         type: boolean
@@ -583,7 +583,7 @@ paths:
                         type: string
                 -   name: embed
                     in: query
-                    description: Comma separated list of additonal fields to embed
+                    description: Comma separated list of additional fields to embed
                     required: false
                     schema:
                         type: string
@@ -1437,7 +1437,7 @@ paths:
                         type: string
             responses:
                 "200":
-                    description: Newsletter subscriber succesfully deleted
+                    description: Newsletter subscriber successfully deleted
                     content:
                         application/json:
                             schema:
@@ -3548,7 +3548,7 @@ components:
                     description: Comment as added by merchant
                     type: string
         OrderDebtor:
-            description: Order debitor details
+            description: Order debtor details
             properties:
                 id:
                     description: "ID of the corresponding customer, if any"
@@ -3578,7 +3578,7 @@ components:
                     description: "Bankaccount number (deprecated: use InvoiceAddress.bankaccount)"
                     type: string
                 link_to_account:
-                    description: Link to debitor account
+                    description: Link to debtor account
                     type: boolean
                 address:
                     $ref: "#/components/schemas/OrderAddress"
@@ -3939,14 +3939,14 @@ components:
                     properties:
                         cost:
                             description: Charge per transaction for the given method, can be
-                                a combination of fixed and percentual
+                                a combination of fixed and percentage
                             type: object
                             properties:
                                 amount:
                                     description: Fixed charge per transaction
                                     type: string
                                 percentage:
-                                    description: Percentual charge per transaction
+                                    description: Percentage charge per transaction
                                     type: string
         OrderShippingCountry:
             description: Order shipping country settings

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1215,7 +1215,7 @@ paths:
                                 type: array
                                 items:
                                     $ref: "#/components/schemas/PageSection"
-                        text/xml:
+                        application/xml:
                             schema:
                                 type: array
                                 items:
@@ -1255,7 +1255,7 @@ paths:
                                 type: array
                                 items:
                                     $ref: "#/components/schemas/PageSection"
-                        text/xml:
+                        application/xml:
                             schema:
                                 type: array
                                 items:
@@ -1279,7 +1279,7 @@ paths:
                                     type: string
                                     format: binary
             responses:
-                "200":
+                200:
                     description: The uploaded image's ID.
                     content:
                         application/json:
@@ -1291,7 +1291,7 @@ paths:
                                         description: The unique identifier of the uploaded image.
                                 example:
                                     imageId: 3594
-                        text/xml:
+                        application/xml:
                             schema:
                                 type: object
                                 properties:

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1,4928 +1,4920 @@
 openapi: 3.0.0
 info:
-  title: MyOnlineStore Connect | API
-  contact:
-    name: MyOnlineStore
-  version: '1'
-  description: |
-    # Introduction
-    An online store should be within everyone’s reach. That’s why creating the best online platform is our mission. And we don’t do that just by ourselves. Let's join forces and offer our 39.000+ customers the opportunity to follow their dream. Today is the day!
-
-    * Curious about a collaboration with us? Check our [partner page](https://www.mijnwebwinkel.nl/partners) or [contact us](https://www.mijnwebwinkel.nl/contact)
-    * A [sandbox UI](swagger-docs) is available to test your requests
-    * The changelog can be found [here](swagger-docs/changelog.html)
-
-    # Environments
-    A single (live) environment is available:
-    * api.myonlinestore.com - EMEA area
-
-    # Versions
-    Currently available are versions **1** and **2-beta**.
-    Both are stable, but backwards incompatible changes may be applied to v**-beta**
-    and deprecated options from **1** are removed in **2-beta**. The XML format has also slightly changed
-    between **1** and **2-beta**, though contents are the same
-
-    # Guides
-    ## Business models
-    For our purposes a business model reflects the type of sale made in an order. We currently distinguish "business to customer" (`B2C`) and
-    "business to business" (`B2B`) models. Each order is assigned a model, with B2C being the default. The merchant can specify which model(s)
-    may be used for new orders (pending package/version limitations)
-
-    For an order to qualify for the `B2B` model, the following requirements apply:
-
-    * The merchant must have allowed this model to be used (__Store__._available_business_models_ must be `ALL` or `B2B`)
-    * __OrderDebtor__._address_._invoice_._company_ must not be empty
-    * The selected payment method must allow `B2B` sales. Notably: `Klarna Checkout`, `Klarna Pay Later` and `Afterpay` do not support this model
-
-    If the B2B model applies to an order, some additional options are available:
-
-    * __Order__._reference_ may be set to an arbritary string
-    * __OrderDebtor__._address_._invoice_._taxnumber_ may be set to a valid VAT number
-      (this is not required, but recommended to allow the merchant to verify tax rule applicability)
-    * Vat reverse charging becomes available as a valid tax strategy (see Tax rules section)
-
-    ## Tax rules
-    Depending on the type of sale, country of origin and destination country, some special tax rules may apply to an order. This is reflected in a "tax strategy"
-
-    We currently distinguish the following cases:
-    * Sales within the domestic borders (origin and destination country are the same): regular tax applies
-    * Sales wholly outside EU borders (both origin and destination country not part of the EU): regular tax applies
-    * Sales crossing the EU border (origin country part of the EU and destination country not part of the EU, or vice versa): 0% tax is applied
-    * B2B Sales crossing domestic borders, but not the EU border (both origin and destination country are part of the EU, but not the same):
-      VAT is reverse charged, 0% tax is applied
-
-    The tax strategy is derived based on order and store information and cannot be specified as input
-
-    ## Payment information
-    MyOnlineStore orders may be paid using a number of payment methods, through various gateways.
-    A payment choice is uniquely specified by the combination of gateway_name and method_name.
-    MyOnlineStore also offers one internal gateway (`basic`) which may be used for manually verifiable payments
-    (for example: cash or card at the counter)
-
-    Orders may follow one of two payment flows:
-
-    1. The order has zero or more transactions. At this time the transaction amount will always equal the
-    full order amount (including tax), but partial payments may be added in the future. To be considered finished,
-    at least one transaction must have reached pending, authorized or captured status.
-
-    2. The order has a directly linked singular payment. This option will be deprecated soon,
-    but may still be reflected in historical data and orders created through the API endpoint
-
-    Each order has a payment status (`payment_status`), which is derived from either the transactions from option 1
-    or the singular payment from option 2. This will be one of the following:
-
-    * `new`: The attached transaction has been created, but has not yet been confirmed by the gateway
-    * `pending`: The attached transaction has been updated with a reference to the corresponding transaction at the gateway
-    * `authorized`: The full order amount amount has been confirmed and reserved at the customer's account
-    * `captured`: The full order amount has been transferred to the merchant's account
-    * `incomplete`: This is an external gateway status which may occur if we fetch the status upstream, may be considered as `new`
-    * 'failed': The attached transaction has failed to complete
-    * `refunded`: The full order amount has been refunded
-    * `voided`: The full order amount was reserved (authorized) but this reservation was subsequently cancelled
-    * `unknown`: No payment status can be derived
-
-    ### Special cases
-    * Orders with a total price of 0.00: These do not require any payment information. They may be assigned a method,
-    but will never have any transactions attached.
-    * Credit orders: These do not have any direct payment information attached.
-    For an up-to-date status, transactions and mutations, the original order should be requested.
-  x-logo:
-    url: images/mos-connect-logo.png
-security:
-  - StoreToken:
-      [ ]
-    PartnerToken:
-      [ ]
-paths:
-  "/v{version}/articles":
-    get:
-      tags:
-        - Articles
-      summary: Return a collection of articles
-      description: Returns a listing of articles for the store
-      operationId: getArticles
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/limit"
-        - $ref: "#/components/parameters/offset"
-        - $ref: "#/components/parameters/created_start_date"
-        - $ref: "#/components/parameters/created_end_date"
-        - $ref: "#/components/parameters/changed_start_date"
-        - $ref: "#/components/parameters/changed_end_date"
-        - $ref: "#/components/parameters/ids"
-        - $ref: "#/components/parameters/uuids"
-      responses:
-        "200":
-          description: Article list
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Article"
-            text/xml:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Article"
-    post:
-      tags:
-        - Articles
-      summary: Create a new article
-      description: Create a new article
-      operationId: postArticle
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ArticlePostable"
-        description: Article data
-        required: true
-      responses:
-        "200":
-          description: Article details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Article"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/Article"
-  "/v{version}/articles/{article_id}":
-    get:
-      tags:
-        - Articles
-      summary: Return a single article
-      description: Returns a specific article
-      operationId: getArticle
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/use_url_id"
-        - name: article_id
-          in: path
-          description: Article id
-          required: true
-          schema:
-            type: integer
-      responses:
-        "200":
-          description: Article details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Article"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/Article"
-    delete:
-      tags:
-        - Articles
-      summary: Remove Article
-      description: Remove article
-      operationId: deleteArticle
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/use_url_id"
-        - name: article_id
-          in: path
-          description: Article id
-          required: true
-          schema:
-            type: integer
-      responses:
-        "200":
-          description: Article successfully deleted
-          content:
-            application/json:
-              schema:
-                type: string
-            text/xml:
-              schema:
-                type: string
-    patch:
-      tags:
-        - Articles
-      summary: Change a single article
-      description: Change a specific article
-      operationId: patchArticle
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/use_url_id"
-        - name: article_id
-          in: path
-          description: Article id
-          required: true
-          schema:
-            type: integer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ArticlePatchable"
-        description: Article with attributes to change
-        required: true
-      responses:
-        "200":
-          description: Article details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Article"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/Article"
-  "/v{version}/articles/uploadImage/{article_id}":
-    post:
-      tags:
-        - Articles
-      summary: Upload a new image for article
-      description: Upload and attach an image to an article without interim storage
-      operationId: postUploadImage
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - name: article_id
-          in: path
-          description: Article id
-          required: true
-          schema:
-            type: integer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ArticleUploadImagePostable"
-        description: Image data
-        required: true
-      responses:
-        "200":
-          description: success
-          content:
-            application/json:
-              schema:
-                type: string
-            text/xml:
-              schema:
-                type: string
-  "/v{version}/deleteImage/{image_id}":
-    delete:
-      tags:
-        - Articles
-      summary: Delete image for article
-      description: This will remove an image
-      operationId: deleteImage
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - name: image_id
-          in: path
-          description: Image id
-          required: true
-          schema:
-            type: integer
-      responses:
-        "204":
-          description: Success, empty response
-  "/v{version}/articles/count":
-    get:
-      tags:
-        - Articles
-      summary: Return the number of available articles
-      description: Returns the number of available articles
-      operationId: getArticleCount
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/created_start_date"
-        - $ref: "#/components/parameters/created_end_date"
-        - $ref: "#/components/parameters/changed_start_date"
-        - $ref: "#/components/parameters/changed_end_date"
-      responses:
-        "200":
-          description: Number of available articles
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CountResponse"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/CountResponse"
-  "/v{version}/articlefields/{article_id}":
-    post:
-      tags:
-        - ArticleFields
-      summary: Create new StoreArticleFields
-      description: Add new merchant specified article field(s)
-      operationId: postArticleFields
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/use_url_id"
-        - name: article_id
-          in: path
-          description: Article id
-          required: true
-          schema:
-            type: integer
-        - name: visible
-          in: query
-          description: Whether this field should be visibile or invisble to shop visitors
-          required: true
-          schema:
-            type: boolean
-            default: true
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              example:
-                fieldname: value
-              additionalProperties:
-                type: string
-        description: Name => value pairs
-        required: true
-      responses:
-        "200":
-          description: Article details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Article"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/Article"
-    delete:
-      tags:
-        - ArticleFields
-      summary: Remove StoreArticleFields
-      description: Remove merchant specified article field(s)
-      operationId: deleteArticleFields
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/use_url_id"
-        - name: article_id
-          in: path
-          description: Article id
-          required: true
-          schema:
-            type: integer
-        - name: visible
-          in: query
-          description: Whether this field should be visibile or invisble to shop visitors
-          required: true
-          schema:
-            type: boolean
-            default: true
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                description: Name of a field to remove
-                type: string
-        required: true
-      responses:
-        "200":
-          description: Article details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Article"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/Article"
-  "/v{version}/articlelistoptions/{articlelist_id}":
-    post:
-      tags:
-        - ArticleListOptions
-      summary: Create new ArticleListOptions
-      description: Add new options to an articlelist
-      operationId: postArticleListOptions
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - name: articlelist_id
-          in: path
-          description: Articlelist id
-          required: true
-          schema:
-            type: integer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: "#/components/schemas/ArticleListOption"
-        description: Set of list options
-        required: true
-      responses:
-        "200":
-          description: Articlelist details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ArticleList"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/ArticleList"
-    delete:
-      tags:
-        - ArticleListOptions
-      summary: Remove options from an ArticleList
-      description: Remove options from an articlelist
-      operationId: deleteArticleListOptions
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - name: articlelist_id
-          in: path
-          description: Articlelist id
-          required: true
-          schema:
-            type: integer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                type: string
-        description: Option names
-        required: true
-      responses:
-        "200":
-          description: Articlelist details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ArticleList"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/ArticleList"
-  "/v{version}/articlelists/{id}":
-    get:
-      tags:
-        - ArticleLists
-      summary: Get a specific article list
-      description: Get a specific article list
-      operationId: getArticleList
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - name: id
-          in: path
-          description: Articlelist id
-          required: true
-          schema:
-            type: integer
-      responses:
-        "200":
-          description: Articlelist details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ArticleList"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/ArticleList"
-    post:
-      tags:
-        - ArticleLists
-      summary: Add articleLists to an Article
-      description: Add lists to an Article
-      operationId: postArticleLists
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/use_url_id"
-        - name: id
-          in: path
-          description: Article id
-          required: true
-          schema:
-            type: integer
-      requestBody:
-        $ref: "#/components/requestBodies/postArticleListsLists"
-      responses:
-        "200":
-          description: Article details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Article"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/Article"
-    delete:
-      tags:
-        - ArticleLists
-      summary: Remove articleLists from an Article
-      description: Remove lists from an Article
-      operationId: deleteArticleLists
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/use_url_id"
-        - name: id
-          in: path
-          description: Article id
-          required: true
-          schema:
-            type: integer
-      requestBody:
-        $ref: "#/components/requestBodies/postArticleListsLists"
-      responses:
-        "200":
-          description: Article details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Article"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/Article"
-  "/v{version}/customers":
-    get:
-      tags:
-        - Customers
-      summary: Listing
-      description: Returns a listing of customers that belong to the given store token.
-      operationId: getCustomers
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - name: q
-          in: query
-          description: Search query to find customers by their email
-          required: false
-          schema:
-            type: string
-        - name: embed
-          in: query
-          description: Comma separated list of additonal fields to embed
-          required: false
-          schema:
-            type: string
-            enum:
-              - address
-      responses:
-        "200":
-          description: Customers
-          content:
-            application/json:
-              schema:
-                properties:
-                  customers:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/Customer"
-    post:
-      tags:
-        - Customers
-      summary: Create
-      description: Create a new customer.
-      operationId: createCustomer
-      parameters:
-        - $ref: "#/components/parameters/version"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              properties:
-                email:
-                  description: Email address
-                  type: string
-                  format: email
-                firstName:
-                  description: First name
-                  type: string
-                lastName:
-                  description: Last name
-                  type: string
-      responses:
-        "200":
-          description: Customer
-          content:
-            application/json:
-              schema:
-                properties:
-                  customer:
-                    $ref: "#/components/schemas/Customer"
-  "/v{version}/customers/{customerId}":
-    get:
-      tags:
-        - Customers
-      summary: Single
-      description: Returns a specific customer by its identifier.
-      operationId: getCustomer
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/customer_id_path"
-      responses:
-        "200":
-          description: Customer
-          content:
-            application/json:
-              schema:
-                properties:
-                  customer:
-                    $ref: "#/components/schemas/Customer"
-    patch:
-      tags:
-        - Customers
-      summary: Update
-      description: Update a specific customer by its identifier.
-      operationId: patchCustomer
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/customer_id_path"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CustomerPatchable"
-      responses:
-        "200":
-          description: Customer
-          content:
-            application/json:
-              schema:
-                properties:
-                  customer:
-                    $ref: "#/components/schemas/Customer"
-        "422":
-          description: Invalid Payload (RFC7807 Problem Details)
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiProblem"
-    delete:
-      tags:
-        - Customers
-      summary: Remove
-      description: Remove a specific customer by its identifier.
-      operationId: deleteCustomer
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/customer_id_path"
-      responses:
-        "200":
-          description: Empty Response
-  "/v{version}/customers/{customerId}/addresses":
-    get:
-      tags:
-        - Customers
-      summary: Address Listing
-      description: Returns a listing of addresses for the given customer.
-      operationId: getCustomersAddresses
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/customer_id_path"
-      responses:
-        "200":
-          description: Addresses
-          content:
-            application/json:
-              schema:
-                properties:
-                  addresses:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/CustomerAddress"
-    post:
-      tags:
-        - Customers
-      summary: Address Create
-      description: Add a new address for given customer.
-      operationId: postCustomersAddress
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/customer_id_path"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CustomerAddressPostable"
-      responses:
-        "200":
-          description: Address
-          content:
-            application/json:
-              schema:
-                properties:
-                  address:
-                    $ref: "#/components/schemas/CustomerAddress"
-        "422":
-          description: Invalid Payload (RFC7807 Problem Details)
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiProblem"
-  "/v{version}/customers/{customerId}/addresses/{addressId}":
-    get:
-      tags:
-        - Customers
-      summary: Address Single
-      description: Returns a specific address by its identifier.
-      operationId: getCustomersAddress
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/customer_id_path"
-        - $ref: "#/components/parameters/customer_address_id_path"
-      responses:
-        "200":
-          description: Address
-          content:
-            application/json:
-              schema:
-                properties:
-                  address:
-                    $ref: "#/components/schemas/CustomerAddress"
-    patch:
-      tags:
-        - Customers
-      summary: Address Update
-      description: Update a specific address by its identifier.
-      operationId: patchCustomersAddress
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/customer_id_path"
-        - $ref: "#/components/parameters/customer_address_id_path"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CustomerAddressPatchable"
-      responses:
-        "200":
-          description: Address
-          content:
-            application/json:
-              schema:
-                properties:
-                  address:
-                    $ref: "#/components/schemas/CustomerAddress"
-        "422":
-          description: Invalid Payload (RFC7807 Problem Details)
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiProblem"
-    delete:
-      tags:
-        - Customers
-      summary: Address Remove
-      description: Remove a specific address by its identifier.
-      operationId: deleteCustomersAddress
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/customer_id_path"
-        - $ref: "#/components/parameters/customer_address_id_path"
-      responses:
-        "200":
-          description: Empty Response
-  "/v{version}/orders":
-    get:
-      tags:
-        - Orders
-      summary: Listing
-      description: Returns a listing of orders for the store
-      operationId: getOrders
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/limit"
-        - $ref: "#/components/parameters/offset"
-        - $ref: "#/components/parameters/start_date"
-        - $ref: "#/components/parameters/end_date"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/archived"
-        - $ref: "#/components/parameters/status_id"
-        - $ref: "#/components/parameters/status_changed_start_date"
-        - $ref: "#/components/parameters/status_changed_end_date"
-        - $ref: "#/components/parameters/debtor_email"
-        - $ref: "#/components/parameters/debtor_id"
-        - $ref: "#/components/parameters/test"
-        - name: ordering
-          in: query
-          description: Ordering (by ordernumber)
-          required: false
-          schema:
-            type: string
-            enum:
-              - asc
-              - desc
-            default: asc
-      responses:
-        "200":
-          description: Order list
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Order"
-            text/xml:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Order"
-    post:
-      tags:
-        - Orders
-      summary: Create
-      description: Create a new order
-      operationId: postOrder
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/language"
-        - name: send_customer_notification
-          in: query
-          description: Send an order confirmation to the customer
-          required: false
-          schema:
-            type: boolean
-            default: false
-        - name: send_merchant_notification
-          in: query
-          description: Send a new order notification to the merchant (if enabled in
-            notification settings)
-          required: false
-          schema:
-            type: boolean
-            default: false
-        - name: override_stock
-          in: query
-          description: Ignore stock limitations on articles, mutations are still applied.
-            (special access required)
-          required: false
-          schema:
-            type: boolean
-            default: false
-        - name: disable_shipping
-          in: query
-          description: Disable the shipping costs calculation of the order
-          required: false
-          schema:
-            type: boolean
-            default: false
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/OrderPostable"
-        description: Order details
-        required: true
-      responses:
-        "200":
-          description: Order details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Order"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/Order"
-  "/v{version}/orders/count":
-    get:
-      tags:
-        - Orders
-      summary: Count
-      description: Returns the number of available orders
-      operationId: getOrderCount
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/start_date"
-        - $ref: "#/components/parameters/end_date"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/archived"
-        - $ref: "#/components/parameters/status_id"
-        - $ref: "#/components/parameters/status_changed_start_date"
-        - $ref: "#/components/parameters/status_changed_end_date"
-        - $ref: "#/components/parameters/test"
-      responses:
-        "200":
-          description: number of available orders
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CountResponse"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/CountResponse"
-  "/v{version}/orders/{order_number}":
-    get:
-      tags:
-        - Orders
-      summary: Single
-      description: Returns a specific order
-      operationId: getOrder
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/order_number_path"
-      responses:
-        "200":
-          description: Order details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Order"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/Order"
-    patch:
-      tags:
-        - Orders
-      summary: Update
-      description: Change a specific order
-      operationId: patchOrder
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/order_number_path"
-        - name: override_minimum
-          in: query
-          description: Ignore minimum order total limitations (special access required)
-          required: false
-          schema:
-            type: boolean
-            default: false
-        - name: override_stock
-          in: query
-          description: Ignore stock limitations on articles, mutations are still applied.
-            (special access required)
-          required: false
-          schema:
-            type: boolean
-            default: false
-        - name: mutate_stock
-          in: query
-          description: Perform stock mutations (applies to credit orders only!)
-          required: false
-          schema:
-            type: boolean
-            default: true
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/OrderPatchable"
-        description: Order attributes to change
-        required: true
-      responses:
-        "200":
-          description: Order details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Order"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/Order"
-  "/v{version}/categories/{category_id}":
-    get:
-      tags:
-        - Categories (Pages)
-      description: Returns a specific category
-      operationId: getCategory
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - name: category_id
-          in: path
-          description: Category id
-          required: true
-          schema:
-            type: integer
-      responses:
-        "200":
-          description: Category details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Category"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/Category"
-    patch:
-      tags:
-        - Categories (Pages)
-      description: Update category page
-      operationId: patchCategory
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - name: category_id
-          in: path
-          description: Category id
-          required: true
-          schema:
-            type: integer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CategoryPatchable"
-        description: Category
-        required: true
-      responses:
-        "200":
-          description: Category details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Category"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/Category"
-  "/v{version}/categories":
-    get:
-      tags:
-        - Categories (Pages)
-      description: Returns a listing of pages for the store
-      operationId: getCategories
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/limit"
-        - $ref: "#/components/parameters/offset"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/created_start_date"
-        - $ref: "#/components/parameters/created_end_date"
-        - $ref: "#/components/parameters/changed_start_date"
-        - $ref: "#/components/parameters/changed_end_date"
-        - name: as_tree
-          in: query
-          description: |-
-            Display as an ordered tree structure, as used in the store.
-            (note: limit & offset have no effect in this mode)
-          required: true
-          schema:
-            type: boolean
-            default: false
-        - name: max_depth
-          in: query
-          description: Maximum depth for tree structure
-          required: false
-          schema:
-            type: integer
-            default: 5
-      responses:
-        "200":
-          description: Category list
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Category"
-            text/xml:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Category"
-    post:
-      tags:
-        - Categories (Pages)
-      description: Create a new category page
-      operationId: postCategory
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CategoryPostable"
-        description: Category
-        required: true
-      responses:
-        "200":
-          description: Category details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Category"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/Category"
-  "/v{version}/categories/{category_id}/articles":
-    get:
-      tags:
-        - Categories (Pages)
-      description: Returns a listing of articles from a category
-      operationId: getCategoryArticles
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/limit"
-        - $ref: "#/components/parameters/offset"
-        - name: category_id
-          in: path
-          description: Category id
-          required: true
-          schema:
-            type: integer
-      responses:
-        "200":
-          description: Articles
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ArticleLimited"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/ArticleLimited"
-  "/v{version}/categories/count":
-    get:
-      tags:
-        - Categories (Pages)
-      description: Returns the number of available categories
-      operationId: getCategoryCount
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/created_start_date"
-        - $ref: "#/components/parameters/created_end_date"
-        - $ref: "#/components/parameters/changed_start_date"
-        - $ref: "#/components/parameters/changed_end_date"
-      responses:
-        "200":
-          description: Number of available categories
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CountResponse"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/CountResponse"
-  "/v{version}/discountcodes":
-    get:
-      tags:
-        - Discountcodes
-      description: Returns a listing of discountcodes for the store
-      operationId: getDiscountcodes
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/format"
-        - name: active
-          in: query
-          description: Only (in)active discountcodes
-          required: false
-          schema:
-            type: boolean
-        - name: valid_start_date
-          in: query
-          description: "Filter on discountcodes which are valid from the specified
-            date(format: yyyy-mm-dd). May also return discountcodes without
-            validity limits"
-          required: false
-          schema:
-            type: string
-            format: date
-        - name: valid_end_date
-          in: query
-          description: "Filter on discountcodes which are valid until the specified
-            date(format: yyyy-mm-dd). May also return discountcodes without
-            validity limits"
-          required: false
-          schema:
-            type: string
-            format: date
-      responses:
-        "200":
-          description: List of discountcodes
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Discountcode"
-            text/xml:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Discountcode"
-    post:
-      tags:
-        - Discountcodes
-      description: Create a new discountcode
-      operationId: postDiscountcode
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/format"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/DiscountcodePostable"
-        description: Discountcode with attributes to set
-        required: true
-      responses:
-        "200":
-          description: Discountcode details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Discountcode"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/Discountcode"
-    patch:
-      tags:
-        - Discountcodes
-      description: Change a specific discountcode
-      operationId: patchDiscountcode
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/format"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/DiscountcodePatchable"
-        description: Discountcode with attributes to change
-        required: true
-      responses:
-        "200":
-          description: Discountcode details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Discountcode"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/Discountcode"
-  "/v{version}/discountcodes/{code}":
-    get:
-      tags:
-        - Discountcodes
-      description: Returns a specific discountcode
-      operationId: getDiscountcode
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/format"
-        - name: code
-          in: path
-          description: Unique discountcode identifier
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Discountcode details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Discountcode"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/Discountcode"
-    delete:
-      tags:
-        - Discountcodes
-      description: Remove a specific discountcode
-      operationId: deleteDiscountcode
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/format"
-        - name: code
-          in: path
-          description: Unique discountcode identifier
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Discountcode successfully deleted
-          content:
-            application/json:
-              schema:
-                type: string
-            text/xml:
-              schema:
-                type: string
-  "/v{version}/newsletter/subscribers":
-    get:
-      tags:
-        - NewsletterSubscribers
-      description: Returns a listing of newsletter subscribers for the store
-      operationId: getNewsletterSubscribers
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/limit"
-        - $ref: "#/components/parameters/offset"
-        - $ref: "#/components/parameters/activated"
-        - $ref: "#/components/parameters/created_start_date"
-        - $ref: "#/components/parameters/created_end_date"
-        - $ref: "#/components/parameters/changed_start_date"
-        - $ref: "#/components/parameters/changed_end_date"
-      responses:
-        "200":
-          description: List of newsletter subscribers
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/NewsletterSubscriber"
-            text/xml:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/NewsletterSubscriber"
-    post:
-      tags:
-        - NewsletterSubscribers
-      description: Create a new newsletter subscriber
-      operationId: postNewsletterSubscriber
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/activate"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/NewsletterSubscriberPostable"
-        description: Newsletter subscriber with attributes to change
-        required: true
-      responses:
-        "200":
-          description: Newsletter subscriber details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/NewsletterSubscriber"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/NewsletterSubscriber"
-  "/v{version}/newsletter/subscribers/{email}":
-    get:
-      tags:
-        - NewsletterSubscribers
-      description: Returns a specific newsletter subscriber
-      operationId: getNewsletterSubscriber
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - name: email
-          in: path
-          description: Newsletter subscriber email address
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Newsletter subscriber details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/NewsletterSubscriber"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/NewsletterSubscriber"
-    delete:
-      tags:
-        - NewsletterSubscribers
-      description: Remove a specific newsletter subscriber
-      operationId: deleteNewsletterSubscriber
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - name: email
-          in: path
-          description: Newsletter subscriber email address
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Newsletter subscriber succesfully deleted
-          content:
-            application/json:
-              schema:
-                type: string
-            text/xml:
-              schema:
-                type: string
-    patch:
-      tags:
-        - NewsletterSubscribers
-      description: Change a specific newsletter subscribers
-      operationId: patchNewsletterSubscriber
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/activate"
-        - name: email
-          in: path
-          description: Newsletter subscriber email address
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/NewsletterSubscriberPatchable"
-        description: Newsletter subscriber with attributes to change
-        required: true
-      responses:
-        "200":
-          description: Newsletter subscriber details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/NewsletterSubscriber"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/NewsletterSubscriber"
-  "/v{version}/newsletter/subscribers/count":
-    get:
-      tags:
-        - NewsletterSubscribers
-      description: Returns the number of available newsletter subscribers
-      operationId: countNewsletterSubscribers
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/activated"
-        - $ref: "#/components/parameters/created_start_date"
-        - $ref: "#/components/parameters/created_end_date"
-        - $ref: "#/components/parameters/changed_start_date"
-        - $ref: "#/components/parameters/changed_end_date"
-      responses:
-        "200":
-          description: Number of available newsletter subscribers
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CountResponse"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/CountResponse"
-  "/v{version}/offlinelocations":
-    get:
-      tags:
-        - OfflineLocations
-      description: Returns a listing of offline (POS) locations for the store
-      operationId: getOfflineLocations
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/format"
-        - name: deleted
-          in: query
-          description: Filter (soft) deleted locations
-          required: false
-          schema:
-            type: boolean
-      responses:
-        "200":
-          description: List of offline (POS) locations
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/OfflineLocation"
-            text/xml:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/OfflineLocation"
-  "/v{version}/offlinelocations/{id}":
-    get:
-      tags:
-        - OfflineLocations
-      description: Returns a specific offline (POS) location
-      operationId: getOfflineLocation
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/format"
-        - name: id
-          in: path
-          description: Unique location identifier (UUID string)
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Offline location details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/OfflineLocation"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/OfflineLocation"
-  "/v{version}/orders/credit":
-    post:
-      tags:
-        - Orders
-      summary: Credit Create
-      description: Create a credit order for an existing order
-      operationId: postCreditOrder
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/language"
-        - name: mutate_stock
-          in: query
-          description: Perform stock mutations, reverting (specified) mutations of the
-            original order
-          required: false
-          schema:
-            type: boolean
-            default: true
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreditOrderPostable"
-        description: Credit order specification
-        required: true
-      responses:
-        "200":
-          description: Order details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Order"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/Order"
-  "/v{version}/orders/{order_number}/payments":
-    get:
-      tags:
-        - Orders
-        - Payments
-      summary: Payment Listing
-      description: Return a listing of payments for the given order.
-      operationId: getOrderPayments
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/order_number_path"
-        - $ref: "#/components/parameters/payment_embed"
-      responses:
-        "200":
-          description: Order payments details
-          content:
-            application/json:
-              schema:
-                properties:
-                  payments:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/Payment"
-    post:
-      tags:
-        - Orders
-        - Payments
-      summary: Payment Create
-      description: Add a new payment for the given order.
-      operationId: postOrderPayment
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/order_number_path"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/OrderPaymentPostable"
-      responses:
-        "201":
-          description: Order payment details
-          content:
-            application/json:
-              schema:
-                properties:
-                  payment:
-                    $ref: "#/components/schemas/Payment"
-                  url:
-                    description: URL contains either the referrer url, or the url for starting the payment
-                    type: string
-        "422":
-          description: Invalid Payload (RFC7807 Problem Details)
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiProblem"
-  "/v{version}/orders/{order_number}/payments/{paymentId}":
-    patch:
-      tags:
-        - Orders
-        - Payments
-      summary: Payment Update
-      description: Update a specific payment by its identifier.
-      operationId: patchOrderPayment
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/order_number_path"
-        - $ref: "#/components/parameters/payment_id_path"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/OrderPaymentPatchable"
-      responses:
-        "200":
-          description: Order payment details
-          content:
-            application/json:
-              schema:
-                properties:
-                  payment:
-                    $ref: "#/components/schemas/Payment"
-        "422":
-          description: Invalid Payload (RFC7807 Problem Details)
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiProblem"
-    delete:
-      tags:
-        - Orders
-        - Payments
-      summary: Payment Remove
-      description: Remove a specific payment by its identifier.
-      operationId: deleteOrderPayment
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/order_number_path"
-        - $ref: "#/components/parameters/payment_id_path"
-      responses:
-        "204":
-          description: Empty Response
-  "/v{version}/orderstatuses":
-    get:
-      tags:
-        - Order statuses
-      description: Returns a listing of all available order statuses.
-      operationId: getOrderStatuses
-      security:
-        - PartnerToken:
-            [ ]
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-      responses:
-        "200":
-          description: Order status list
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/OrderStatus"
-            text/xml:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/OrderStatus"
-  "/v{version}/payment/gateways":
-    get:
-      tags:
-        - Payment Gateways
-      description: Retrieve a listing of all available payment gateways and methods
-      operationId: getGateways
-      security:
-        - PartnerToken:
-            [ ]
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-      responses:
-        "200":
-          description: List of gateways
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PaymentGateways"
-  "/v{version}/payment/stores/{store}/gateways":
-    get:
-      tags:
-        - Payment Gateways
-      description: Retrieve a listing of all payment gateways and methods available in the given store
-      operationId: getStoreGateways
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/store"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-      responses:
-        "200":
-          description: List of gateways
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/StorePaymentGateways"
-  "/v{version}/tax-policy/regions":
-    get:
-      tags:
-        - TaxPolicyRegion
-      summary: Listing
-      description: Retrieve a list of all configured tax policy regions
-      operationId: TaxPolicyRegionList
-      parameters:
-        -   $ref: "#/components/parameters/version"
-      responses:
-        "200":
-          description: Tax policy regions
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/TaxPolicyRegion"
-  "/v{version}/tax-policy/regions/{code}":
-    get:
-      tags:
-        - TaxPolicyRegion
-      summary: Single
-      description: Retrieve a single tax policy region by given code
-      operationId: getTaxPolicyRegion
-      parameters:
-        -   $ref: "#/components/parameters/version"
-        -   $ref: "#/components/parameters/region_code_path"
-      responses:
-        "200":
-          description: Tax policy region
-          content:
-            application/json:
-              schema:
-                properties:
-                  region:
-                    $ref: "#/components/schemas/TaxPolicyRegion"
-  "/v{version}/shipping/methods":
-    get:
-      tags:
-        - Shipping methods
-      description: Returns a listing of available shipping methods for the store
-      operationId: getShippingMethods
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/format"
-      responses:
-        "200":
-          description: List of shipping methods
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ShippingMethod"
-            text/xml:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ShippingMethod"
-  "/v{version}/store":
-    get:
-      tags:
-        - Store information
-      description: Returns details for the store (identified by token)
-      operationId: getStore
-      parameters:
-        - $ref: "#/components/parameters/version"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/format"
-      responses:
-        "200":
-          description: Store details
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Store"
-            text/xml:
-              schema:
-                $ref: "#/components/schemas/Store"
-tags:
-  - name: Store information
-    description: General store details
-  - name: Orders
-    description: Order details
-  - name: Order statuses
-    description: Available order statuses
-  - name: Payment Gateways
-    description: Available payment gateways
-  - name: Shipping methods
-    description: Available shipping methods
-  - name: OfflineLocations
-    description: Point of sale location details
-  - name: Discountcodes
-    description: Available discountcode details
-  - name: NewsletterSubscribers
-    description: Subscriber details for the store's newsletter
-  - name: Categories (Pages)
-    description: Page details
-  - name: Customers
+    title: MyOnlineStore Connect | API
+    contact:
+        name: MyOnlineStore
+    version: '1'
     description: |
-      Store customer accounts.
-      ### Access
-      Due to informational sensitivity, access to these endpoints is restricted. Contact us if you'd like to make use of
-      them in your integration.
-  - name: Articles
-    description: Article details
-  - name: ArticleListOptions
-    description: Options for article lists
-  - name: ArticleLists
-    description: Article (option) list details
-  - name: ArticleFields
-    description: Custom article fields
+        # Introduction
+        An online store should be within everyone’s reach. That’s why creating the best online platform is our mission. And we don’t do that just by ourselves. Let's join forces and offer our 39.000+ customers the opportunity to follow their dream. Today is the day!
+        
+        * Curious about a collaboration with us? Check our [partner page](https://www.mijnwebwinkel.nl/partners) or [contact us](https://www.mijnwebwinkel.nl/contact)
+        * A [sandbox UI](swagger-docs) is available to test your requests
+        * The changelog can be found [here](swagger-docs/changelog.html)
+        
+        # Environments
+        A single (live) environment is available:
+        * api.myonlinestore.com - EMEA area
+        
+        # Versions
+        Currently available are versions **1** and **2-beta**.
+        Both are stable, but backwards incompatible changes may be applied to v**-beta**
+        and deprecated options from **1** are removed in **2-beta**. The XML format has also slightly changed
+        between **1** and **2-beta**, though contents are the same
+        
+        # Guides
+        ## Business models
+        For our purposes a business model reflects the type of sale made in an order. We currently distinguish "business to customer" (`B2C`) and
+        "business to business" (`B2B`) models. Each order is assigned a model, with B2C being the default. The merchant can specify which model(s)
+        may be used for new orders (pending package/version limitations)
+        
+        For an order to qualify for the `B2B` model, the following requirements apply:
+        
+        * The merchant must have allowed this model to be used (__Store__._available_business_models_ must be `ALL` or `B2B`)
+        * __OrderDebtor__._address_._invoice_._company_ must not be empty
+        * The selected payment method must allow `B2B` sales. Notably: `Klarna Checkout`, `Klarna Pay Later` and `Afterpay` do not support this model
+        
+        If the B2B model applies to an order, some additional options are available:
+        
+        * __Order__._reference_ may be set to an arbritary string
+        * __OrderDebtor__._address_._invoice_._taxnumber_ may be set to a valid VAT number
+          (this is not required, but recommended to allow the merchant to verify tax rule applicability)
+        * Vat reverse charging becomes available as a valid tax strategy (see Tax rules section)
+        
+        ## Tax rules
+        Depending on the type of sale, country of origin and destination country, some special tax rules may apply to an order. This is reflected in a "tax strategy"
+        
+        We currently distinguish the following cases:
+        * Sales within the domestic borders (origin and destination country are the same): regular tax applies
+        * Sales wholly outside EU borders (both origin and destination country not part of the EU): regular tax applies
+        * Sales crossing the EU border (origin country part of the EU and destination country not part of the EU, or vice versa): 0% tax is applied
+        * B2B Sales crossing domestic borders, but not the EU border (both origin and destination country are part of the EU, but not the same):
+          VAT is reverse charged, 0% tax is applied
+        
+        The tax strategy is derived based on order and store information and cannot be specified as input
+        
+        ## Payment information
+        MyOnlineStore orders may be paid using a number of payment methods, through various gateways.
+        A payment choice is uniquely specified by the combination of gateway_name and method_name.
+        MyOnlineStore also offers one internal gateway (`basic`) which may be used for manually verifiable payments
+        (for example: cash or card at the counter)
+        
+        Orders may follow one of two payment flows:
+        
+        1. The order has zero or more transactions. At this time the transaction amount will always equal the
+        full order amount (including tax), but partial payments may be added in the future. To be considered finished,
+        at least one transaction must have reached pending, authorized or captured status.
+        
+        2. The order has a directly linked singular payment. This option will be deprecated soon,
+        but may still be reflected in historical data and orders created through the API endpoint
+        
+        Each order has a payment status (`payment_status`), which is derived from either the transactions from option 1
+        or the singular payment from option 2. This will be one of the following:
+        
+        * `new`: The attached transaction has been created, but has not yet been confirmed by the gateway
+        * `pending`: The attached transaction has been updated with a reference to the corresponding transaction at the gateway
+        * `authorized`: The full order amount amount has been confirmed and reserved at the customer's account
+        * `captured`: The full order amount has been transferred to the merchant's account
+        * `incomplete`: This is an external gateway status which may occur if we fetch the status upstream, may be considered as `new`
+        * 'failed': The attached transaction has failed to complete
+        * `refunded`: The full order amount has been refunded
+        * `voided`: The full order amount was reserved (authorized) but this reservation was subsequently cancelled
+        * `unknown`: No payment status can be derived
+        
+        ### Special cases
+        * Orders with a total price of 0.00: These do not require any payment information. They may be assigned a method,
+        but will never have any transactions attached.
+        * Credit orders: These do not have any direct payment information attached.
+        For an up-to-date status, transactions and mutations, the original order should be requested.
+    x-logo:
+        url: images/mos-connect-logo.png
+security:
+    -   StoreToken:
+          [ ]
+        PartnerToken:
+          [ ]
+paths:
+    "/v{version}/articles":
+        get:
+            tags:
+                - Articles
+            summary: Return a collection of articles
+            description: Returns a listing of articles for the store
+            operationId: getArticles
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/limit"
+                -   $ref: "#/components/parameters/offset"
+                -   $ref: "#/components/parameters/created_start_date"
+                -   $ref: "#/components/parameters/created_end_date"
+                -   $ref: "#/components/parameters/changed_start_date"
+                -   $ref: "#/components/parameters/changed_end_date"
+                -   $ref: "#/components/parameters/ids"
+                -   $ref: "#/components/parameters/uuids"
+            responses:
+                "200":
+                    description: Article list
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/Article"
+                        text/xml:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/Article"
+        post:
+            tags:
+                - Articles
+            summary: Create a new article
+            description: Create a new article
+            operationId: postArticle
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ArticlePostable"
+                description: Article data
+                required: true
+            responses:
+                "200":
+                    description: Article details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Article"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/Article"
+    "/v{version}/articles/{article_id}":
+        get:
+            tags:
+                - Articles
+            summary: Return a single article
+            description: Returns a specific article
+            operationId: getArticle
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/use_url_id"
+                -   name: article_id
+                    in: path
+                    description: Article id
+                    required: true
+                    schema:
+                        type: integer
+            responses:
+                "200":
+                    description: Article details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Article"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/Article"
+        delete:
+            tags:
+                - Articles
+            summary: Remove Article
+            description: Remove article
+            operationId: deleteArticle
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/use_url_id"
+                -   name: article_id
+                    in: path
+                    description: Article id
+                    required: true
+                    schema:
+                        type: integer
+            responses:
+                "200":
+                    description: Article successfully deleted
+                    content:
+                        application/json:
+                            schema:
+                                type: string
+                        text/xml:
+                            schema:
+                                type: string
+        patch:
+            tags:
+                - Articles
+            summary: Change a single article
+            description: Change a specific article
+            operationId: patchArticle
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/use_url_id"
+                -   name: article_id
+                    in: path
+                    description: Article id
+                    required: true
+                    schema:
+                        type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ArticlePatchable"
+                description: Article with attributes to change
+                required: true
+            responses:
+                "200":
+                    description: Article details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Article"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/Article"
+    "/v{version}/articles/uploadImage/{article_id}":
+        post:
+            tags:
+                - Articles
+            summary: Upload a new image for article
+            description: Upload and attach an image to an article without interim storage
+            operationId: postUploadImage
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   name: article_id
+                    in: path
+                    description: Article id
+                    required: true
+                    schema:
+                        type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ArticleUploadImagePostable"
+                description: Image data
+                required: true
+            responses:
+                "200":
+                    description: success
+                    content:
+                        application/json:
+                            schema:
+                                type: string
+                        text/xml:
+                            schema:
+                                type: string
+    "/v{version}/deleteImage/{image_id}":
+        delete:
+            tags:
+                - Articles
+            summary: Delete image for article
+            description: This will remove an image
+            operationId: deleteImage
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   name: image_id
+                    in: path
+                    description: Image id
+                    required: true
+                    schema:
+                        type: integer
+            responses:
+                "204":
+                    description: Success, empty response
+    "/v{version}/articles/count":
+        get:
+            tags:
+                - Articles
+            summary: Return the number of available articles
+            description: Returns the number of available articles
+            operationId: getArticleCount
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/created_start_date"
+                -   $ref: "#/components/parameters/created_end_date"
+                -   $ref: "#/components/parameters/changed_start_date"
+                -   $ref: "#/components/parameters/changed_end_date"
+            responses:
+                "200":
+                    description: Number of available articles
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/CountResponse"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/CountResponse"
+    "/v{version}/articlefields/{article_id}":
+        post:
+            tags:
+                - ArticleFields
+            summary: Create new StoreArticleFields
+            description: Add new merchant specified article field(s)
+            operationId: postArticleFields
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/use_url_id"
+                -   name: article_id
+                    in: path
+                    description: Article id
+                    required: true
+                    schema:
+                        type: integer
+                -   name: visible
+                    in: query
+                    description: Whether this field should be visibile or invisble to shop visitors
+                    required: true
+                    schema:
+                        type: boolean
+                        default: true
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            example:
+                                fieldname: value
+                            additionalProperties:
+                                type: string
+                description: Name => value pairs
+                required: true
+            responses:
+                "200":
+                    description: Article details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Article"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/Article"
+        delete:
+            tags:
+                - ArticleFields
+            summary: Remove StoreArticleFields
+            description: Remove merchant specified article field(s)
+            operationId: deleteArticleFields
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/use_url_id"
+                -   name: article_id
+                    in: path
+                    description: Article id
+                    required: true
+                    schema:
+                        type: integer
+                -   name: visible
+                    in: query
+                    description: Whether this field should be visibile or invisble to shop visitors
+                    required: true
+                    schema:
+                        type: boolean
+                        default: true
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            type: array
+                            items:
+                                description: Name of a field to remove
+                                type: string
+                required: true
+            responses:
+                "200":
+                    description: Article details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Article"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/Article"
+    "/v{version}/articlelistoptions/{articlelist_id}":
+        post:
+            tags:
+                - ArticleListOptions
+            summary: Create new ArticleListOptions
+            description: Add new options to an articlelist
+            operationId: postArticleListOptions
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   name: articlelist_id
+                    in: path
+                    description: Articlelist id
+                    required: true
+                    schema:
+                        type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            type: array
+                            items:
+                                $ref: "#/components/schemas/ArticleListOption"
+                description: Set of list options
+                required: true
+            responses:
+                "200":
+                    description: Articlelist details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ArticleList"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/ArticleList"
+        delete:
+            tags:
+                - ArticleListOptions
+            summary: Remove options from an ArticleList
+            description: Remove options from an articlelist
+            operationId: deleteArticleListOptions
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   name: articlelist_id
+                    in: path
+                    description: Articlelist id
+                    required: true
+                    schema:
+                        type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            type: array
+                            items:
+                                type: string
+                description: Option names
+                required: true
+            responses:
+                "200":
+                    description: Articlelist details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ArticleList"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/ArticleList"
+    "/v{version}/articlelists/{id}":
+        get:
+            tags:
+                - ArticleLists
+            summary: Get a specific article list
+            description: Get a specific article list
+            operationId: getArticleList
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   name: id
+                    in: path
+                    description: Articlelist id
+                    required: true
+                    schema:
+                        type: integer
+            responses:
+                "200":
+                    description: Articlelist details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ArticleList"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/ArticleList"
+        post:
+            tags:
+                - ArticleLists
+            summary: Add articleLists to an Article
+            description: Add lists to an Article
+            operationId: postArticleLists
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/use_url_id"
+                -   name: id
+                    in: path
+                    description: Article id
+                    required: true
+                    schema:
+                        type: integer
+            requestBody:
+                $ref: "#/components/requestBodies/postArticleListsLists"
+            responses:
+                "200":
+                    description: Article details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Article"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/Article"
+        delete:
+            tags:
+                - ArticleLists
+            summary: Remove articleLists from an Article
+            description: Remove lists from an Article
+            operationId: deleteArticleLists
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/use_url_id"
+                -   name: id
+                    in: path
+                    description: Article id
+                    required: true
+                    schema:
+                        type: integer
+            requestBody:
+                $ref: "#/components/requestBodies/postArticleListsLists"
+            responses:
+                "200":
+                    description: Article details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Article"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/Article"
+    "/v{version}/customers":
+        get:
+            tags:
+                - Customers
+            summary: Listing
+            description: Returns a listing of customers that belong to the given store token.
+            operationId: getCustomers
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   name: q
+                    in: query
+                    description: Search query to find customers by their email
+                    required: false
+                    schema:
+                        type: string
+                -   name: embed
+                    in: query
+                    description: Comma separated list of additonal fields to embed
+                    required: false
+                    schema:
+                        type: string
+                        enum:
+                            - address
+            responses:
+                "200":
+                    description: Customers
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    customers:
+                                        type: array
+                                        items:
+                                            $ref: "#/components/schemas/Customer"
+        post:
+            tags:
+                - Customers
+            summary: Create
+            description: Create a new customer.
+            operationId: createCustomer
+            parameters:
+                -   $ref: "#/components/parameters/version"
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            properties:
+                                email:
+                                    description: Email address
+                                    type: string
+                                    format: email
+                                firstName:
+                                    description: First name
+                                    type: string
+                                lastName:
+                                    description: Last name
+                                    type: string
+            responses:
+                "200":
+                    description: Customer
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    customer:
+                                        $ref: "#/components/schemas/Customer"
+    "/v{version}/customers/{customerId}":
+        get:
+            tags:
+                - Customers
+            summary: Single
+            description: Returns a specific customer by its identifier.
+            operationId: getCustomer
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/customer_id_path"
+            responses:
+                "200":
+                    description: Customer
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    customer:
+                                        $ref: "#/components/schemas/Customer"
+        patch:
+            tags:
+                - Customers
+            summary: Update
+            description: Update a specific customer by its identifier.
+            operationId: patchCustomer
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/customer_id_path"
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CustomerPatchable"
+            responses:
+                "200":
+                    description: Customer
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    customer:
+                                        $ref: "#/components/schemas/Customer"
+                "422":
+                    description: Invalid Payload (RFC7807 Problem Details)
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiProblem"
+        delete:
+            tags:
+                - Customers
+            summary: Remove
+            description: Remove a specific customer by its identifier.
+            operationId: deleteCustomer
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/customer_id_path"
+            responses:
+                "200":
+                    description: Empty Response
+    "/v{version}/customers/{customerId}/addresses":
+        get:
+            tags:
+                - Customers
+            summary: Address Listing
+            description: Returns a listing of addresses for the given customer.
+            operationId: getCustomersAddresses
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/customer_id_path"
+            responses:
+                "200":
+                    description: Addresses
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    addresses:
+                                        type: array
+                                        items:
+                                            $ref: "#/components/schemas/CustomerAddress"
+        post:
+            tags:
+                - Customers
+            summary: Address Create
+            description: Add a new address for given customer.
+            operationId: postCustomersAddress
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/customer_id_path"
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CustomerAddressPostable"
+            responses:
+                "200":
+                    description: Address
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    address:
+                                        $ref: "#/components/schemas/CustomerAddress"
+                "422":
+                    description: Invalid Payload (RFC7807 Problem Details)
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiProblem"
+    "/v{version}/customers/{customerId}/addresses/{addressId}":
+        get:
+            tags:
+                - Customers
+            summary: Address Single
+            description: Returns a specific address by its identifier.
+            operationId: getCustomersAddress
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/customer_id_path"
+                -   $ref: "#/components/parameters/customer_address_id_path"
+            responses:
+                "200":
+                    description: Address
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    address:
+                                        $ref: "#/components/schemas/CustomerAddress"
+        patch:
+            tags:
+                - Customers
+            summary: Address Update
+            description: Update a specific address by its identifier.
+            operationId: patchCustomersAddress
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/customer_id_path"
+                -   $ref: "#/components/parameters/customer_address_id_path"
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CustomerAddressPatchable"
+            responses:
+                "200":
+                    description: Address
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    address:
+                                        $ref: "#/components/schemas/CustomerAddress"
+                "422":
+                    description: Invalid Payload (RFC7807 Problem Details)
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiProblem"
+        delete:
+            tags:
+                - Customers
+            summary: Address Remove
+            description: Remove a specific address by its identifier.
+            operationId: deleteCustomersAddress
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/customer_id_path"
+                -   $ref: "#/components/parameters/customer_address_id_path"
+            responses:
+                "200":
+                    description: Empty Response
+    "/v{version}/orders":
+        get:
+            tags:
+                - Orders
+            summary: Listing
+            description: Returns a listing of orders for the store
+            operationId: getOrders
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/limit"
+                -   $ref: "#/components/parameters/offset"
+                -   $ref: "#/components/parameters/start_date"
+                -   $ref: "#/components/parameters/end_date"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/archived"
+                -   $ref: "#/components/parameters/status_id"
+                -   $ref: "#/components/parameters/status_changed_start_date"
+                -   $ref: "#/components/parameters/status_changed_end_date"
+                -   $ref: "#/components/parameters/debtor_email"
+                -   $ref: "#/components/parameters/debtor_id"
+                -   $ref: "#/components/parameters/test"
+                -   name: ordering
+                    in: query
+                    description: Ordering (by ordernumber)
+                    required: false
+                    schema:
+                        type: string
+                        enum:
+                            - asc
+                            - desc
+                        default: asc
+            responses:
+                "200":
+                    description: Order list
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/Order"
+                        text/xml:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/Order"
+        post:
+            tags:
+                - Orders
+            summary: Create
+            description: Create a new order
+            operationId: postOrder
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/language"
+                -   name: send_customer_notification
+                    in: query
+                    description: Send an order confirmation to the customer
+                    required: false
+                    schema:
+                        type: boolean
+                        default: false
+                -   name: send_merchant_notification
+                    in: query
+                    description: Send a new order notification to the merchant (if enabled in
+                        notification settings)
+                    required: false
+                    schema:
+                        type: boolean
+                        default: false
+                -   name: override_stock
+                    in: query
+                    description: Ignore stock limitations on articles, mutations are still applied.
+                        (special access required)
+                    required: false
+                    schema:
+                        type: boolean
+                        default: false
+                -   name: disable_shipping
+                    in: query
+                    description: Disable the shipping costs calculation of the order
+                    required: false
+                    schema:
+                        type: boolean
+                        default: false
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/OrderPostable"
+                description: Order details
+                required: true
+            responses:
+                "200":
+                    description: Order details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Order"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/Order"
+    "/v{version}/orders/count":
+        get:
+            tags:
+                - Orders
+            summary: Count
+            description: Returns the number of available orders
+            operationId: getOrderCount
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/start_date"
+                -   $ref: "#/components/parameters/end_date"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/archived"
+                -   $ref: "#/components/parameters/status_id"
+                -   $ref: "#/components/parameters/status_changed_start_date"
+                -   $ref: "#/components/parameters/status_changed_end_date"
+                -   $ref: "#/components/parameters/test"
+            responses:
+                "200":
+                    description: number of available orders
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/CountResponse"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/CountResponse"
+    "/v{version}/orders/{order_number}":
+        get:
+            tags:
+                - Orders
+            summary: Single
+            description: Returns a specific order
+            operationId: getOrder
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/order_number_path"
+            responses:
+                "200":
+                    description: Order details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Order"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/Order"
+        patch:
+            tags:
+                - Orders
+            summary: Update
+            description: Change a specific order
+            operationId: patchOrder
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/order_number_path"
+                -   name: override_minimum
+                    in: query
+                    description: Ignore minimum order total limitations (special access required)
+                    required: false
+                    schema:
+                        type: boolean
+                        default: false
+                -   name: override_stock
+                    in: query
+                    description: Ignore stock limitations on articles, mutations are still applied.
+                        (special access required)
+                    required: false
+                    schema:
+                        type: boolean
+                        default: false
+                -   name: mutate_stock
+                    in: query
+                    description: Perform stock mutations (applies to credit orders only!)
+                    required: false
+                    schema:
+                        type: boolean
+                        default: true
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/OrderPatchable"
+                description: Order attributes to change
+                required: true
+            responses:
+                "200":
+                    description: Order details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Order"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/Order"
+    "/v{version}/categories/{category_id}":
+        get:
+            tags:
+                - Categories (Pages)
+            description: Returns a specific category
+            operationId: getCategory
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   name: category_id
+                    in: path
+                    description: Category id
+                    required: true
+                    schema:
+                        type: integer
+            responses:
+                "200":
+                    description: Category details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Category"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/Category"
+        patch:
+            tags:
+                - Categories (Pages)
+            description: Update category page
+            operationId: patchCategory
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   name: category_id
+                    in: path
+                    description: Category id
+                    required: true
+                    schema:
+                        type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CategoryPatchable"
+                description: Category
+                required: true
+            responses:
+                "200":
+                    description: Category details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Category"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/Category"
+    "/v{version}/categories":
+        get:
+            tags:
+                - Categories (Pages)
+            description: Returns a listing of pages for the store
+            operationId: getCategories
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/limit"
+                -   $ref: "#/components/parameters/offset"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/created_start_date"
+                -   $ref: "#/components/parameters/created_end_date"
+                -   $ref: "#/components/parameters/changed_start_date"
+                -   $ref: "#/components/parameters/changed_end_date"
+                -   name: as_tree
+                    in: query
+                    description: |-
+                        Display as an ordered tree structure, as used in the store.
+                        (note: limit & offset have no effect in this mode)
+                    required: true
+                    schema:
+                        type: boolean
+                        default: false
+                -   name: max_depth
+                    in: query
+                    description: Maximum depth for tree structure
+                    required: false
+                    schema:
+                        type: integer
+                        default: 5
+            responses:
+                "200":
+                    description: Category list
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/Category"
+                        text/xml:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/Category"
+        post:
+            tags:
+                - Categories (Pages)
+            description: Create a new category page
+            operationId: postCategory
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CategoryPostable"
+                description: Category
+                required: true
+            responses:
+                "200":
+                    description: Category details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Category"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/Category"
+    "/v{version}/categories/{category_id}/articles":
+        get:
+            tags:
+                - Categories (Pages)
+            description: Returns a listing of articles from a category
+            operationId: getCategoryArticles
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/limit"
+                -   $ref: "#/components/parameters/offset"
+                -   name: category_id
+                    in: path
+                    description: Category id
+                    required: true
+                    schema:
+                        type: integer
+            responses:
+                "200":
+                    description: Articles
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ArticleLimited"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/ArticleLimited"
+    "/v{version}/categories/count":
+        get:
+            tags:
+                - Categories (Pages)
+            description: Returns the number of available categories
+            operationId: getCategoryCount
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/created_start_date"
+                -   $ref: "#/components/parameters/created_end_date"
+                -   $ref: "#/components/parameters/changed_start_date"
+                -   $ref: "#/components/parameters/changed_end_date"
+            responses:
+                "200":
+                    description: Number of available categories
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/CountResponse"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/CountResponse"
+    "/v{version}/discountcodes":
+        get:
+            tags:
+                - Discountcodes
+            description: Returns a listing of discountcodes for the store
+            operationId: getDiscountcodes
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/format"
+                -   name: active
+                    in: query
+                    description: Only (in)active discountcodes
+                    required: false
+                    schema:
+                        type: boolean
+                -   name: valid_start_date
+                    in: query
+                    description: "Filter on discountcodes which are valid from the specified
+            date(format: yyyy-mm-dd). May also return discountcodes without
+            validity limits"
+                    required: false
+                    schema:
+                        type: string
+                        format: date
+                -   name: valid_end_date
+                    in: query
+                    description: "Filter on discountcodes which are valid until the specified
+            date(format: yyyy-mm-dd). May also return discountcodes without
+            validity limits"
+                    required: false
+                    schema:
+                        type: string
+                        format: date
+            responses:
+                "200":
+                    description: List of discountcodes
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/Discountcode"
+                        text/xml:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/Discountcode"
+        post:
+            tags:
+                - Discountcodes
+            description: Create a new discountcode
+            operationId: postDiscountcode
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/format"
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/DiscountcodePostable"
+                description: Discountcode with attributes to set
+                required: true
+            responses:
+                "200":
+                    description: Discountcode details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Discountcode"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/Discountcode"
+        patch:
+            tags:
+                - Discountcodes
+            description: Change a specific discountcode
+            operationId: patchDiscountcode
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/format"
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/DiscountcodePatchable"
+                description: Discountcode with attributes to change
+                required: true
+            responses:
+                "200":
+                    description: Discountcode details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Discountcode"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/Discountcode"
+    "/v{version}/discountcodes/{code}":
+        get:
+            tags:
+                - Discountcodes
+            description: Returns a specific discountcode
+            operationId: getDiscountcode
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/format"
+                -   name: code
+                    in: path
+                    description: Unique discountcode identifier
+                    required: true
+                    schema:
+                        type: string
+            responses:
+                "200":
+                    description: Discountcode details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Discountcode"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/Discountcode"
+        delete:
+            tags:
+                - Discountcodes
+            description: Remove a specific discountcode
+            operationId: deleteDiscountcode
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/format"
+                -   name: code
+                    in: path
+                    description: Unique discountcode identifier
+                    required: true
+                    schema:
+                        type: string
+            responses:
+                "200":
+                    description: Discountcode successfully deleted
+                    content:
+                        application/json:
+                            schema:
+                                type: string
+                        text/xml:
+                            schema:
+                                type: string
+    "/v{version}/newsletter/subscribers":
+        get:
+            tags:
+                - NewsletterSubscribers
+            description: Returns a listing of newsletter subscribers for the store
+            operationId: getNewsletterSubscribers
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/limit"
+                -   $ref: "#/components/parameters/offset"
+                -   $ref: "#/components/parameters/activated"
+                -   $ref: "#/components/parameters/created_start_date"
+                -   $ref: "#/components/parameters/created_end_date"
+                -   $ref: "#/components/parameters/changed_start_date"
+                -   $ref: "#/components/parameters/changed_end_date"
+            responses:
+                "200":
+                    description: List of newsletter subscribers
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/NewsletterSubscriber"
+                        text/xml:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/NewsletterSubscriber"
+        post:
+            tags:
+                - NewsletterSubscribers
+            description: Create a new newsletter subscriber
+            operationId: postNewsletterSubscriber
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/activate"
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/NewsletterSubscriberPostable"
+                description: Newsletter subscriber with attributes to change
+                required: true
+            responses:
+                "200":
+                    description: Newsletter subscriber details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/NewsletterSubscriber"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/NewsletterSubscriber"
+    "/v{version}/newsletter/subscribers/{email}":
+        get:
+            tags:
+                - NewsletterSubscribers
+            description: Returns a specific newsletter subscriber
+            operationId: getNewsletterSubscriber
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   name: email
+                    in: path
+                    description: Newsletter subscriber email address
+                    required: true
+                    schema:
+                        type: string
+            responses:
+                "200":
+                    description: Newsletter subscriber details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/NewsletterSubscriber"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/NewsletterSubscriber"
+        delete:
+            tags:
+                - NewsletterSubscribers
+            description: Remove a specific newsletter subscriber
+            operationId: deleteNewsletterSubscriber
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   name: email
+                    in: path
+                    description: Newsletter subscriber email address
+                    required: true
+                    schema:
+                        type: string
+            responses:
+                "200":
+                    description: Newsletter subscriber succesfully deleted
+                    content:
+                        application/json:
+                            schema:
+                                type: string
+                        text/xml:
+                            schema:
+                                type: string
+        patch:
+            tags:
+                - NewsletterSubscribers
+            description: Change a specific newsletter subscribers
+            operationId: patchNewsletterSubscriber
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/activate"
+                -   name: email
+                    in: path
+                    description: Newsletter subscriber email address
+                    required: true
+                    schema:
+                        type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/NewsletterSubscriberPatchable"
+                description: Newsletter subscriber with attributes to change
+                required: true
+            responses:
+                "200":
+                    description: Newsletter subscriber details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/NewsletterSubscriber"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/NewsletterSubscriber"
+    "/v{version}/newsletter/subscribers/count":
+        get:
+            tags:
+                - NewsletterSubscribers
+            description: Returns the number of available newsletter subscribers
+            operationId: countNewsletterSubscribers
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/activated"
+                -   $ref: "#/components/parameters/created_start_date"
+                -   $ref: "#/components/parameters/created_end_date"
+                -   $ref: "#/components/parameters/changed_start_date"
+                -   $ref: "#/components/parameters/changed_end_date"
+            responses:
+                "200":
+                    description: Number of available newsletter subscribers
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/CountResponse"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/CountResponse"
+    "/v{version}/offlinelocations":
+        get:
+            tags:
+                - OfflineLocations
+            description: Returns a listing of offline (POS) locations for the store
+            operationId: getOfflineLocations
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/format"
+                -   name: deleted
+                    in: query
+                    description: Filter (soft) deleted locations
+                    required: false
+                    schema:
+                        type: boolean
+            responses:
+                "200":
+                    description: List of offline (POS) locations
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/OfflineLocation"
+                        text/xml:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/OfflineLocation"
+    "/v{version}/offlinelocations/{id}":
+        get:
+            tags:
+                - OfflineLocations
+            description: Returns a specific offline (POS) location
+            operationId: getOfflineLocation
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/format"
+                -   name: id
+                    in: path
+                    description: Unique location identifier (UUID string)
+                    required: true
+                    schema:
+                        type: string
+            responses:
+                "200":
+                    description: Offline location details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/OfflineLocation"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/OfflineLocation"
+    "/v{version}/orders/credit":
+        post:
+            tags:
+                - Orders
+            summary: Credit Create
+            description: Create a credit order for an existing order
+            operationId: postCreditOrder
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/format"
+                -   $ref: "#/components/parameters/language"
+                -   name: mutate_stock
+                    in: query
+                    description: Perform stock mutations, reverting (specified) mutations of the
+                        original order
+                    required: false
+                    schema:
+                        type: boolean
+                        default: true
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreditOrderPostable"
+                description: Credit order specification
+                required: true
+            responses:
+                "200":
+                    description: Order details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Order"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/Order"
+    "/v{version}/orders/{order_number}/payments":
+        get:
+            tags:
+                - Orders
+                - Payments
+            summary: Payment Listing
+            description: Return a listing of payments for the given order.
+            operationId: getOrderPayments
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/order_number_path"
+                -   $ref: "#/components/parameters/payment_embed"
+            responses:
+                "200":
+                    description: Order payments details
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    payments:
+                                        type: array
+                                        items:
+                                            $ref: "#/components/schemas/Payment"
+        post:
+            tags:
+                - Orders
+                - Payments
+            summary: Payment Create
+            description: Add a new payment for the given order.
+            operationId: postOrderPayment
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/order_number_path"
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/OrderPaymentPostable"
+            responses:
+                "201":
+                    description: Order payment details
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    payment:
+                                        $ref: "#/components/schemas/Payment"
+                                    url:
+                                        description: URL contains either the referrer url, or the url for starting the payment
+                                        type: string
+                "422":
+                    description: Invalid Payload (RFC7807 Problem Details)
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiProblem"
+    "/v{version}/orders/{order_number}/payments/{paymentId}":
+        patch:
+            tags:
+                - Orders
+                - Payments
+            summary: Payment Update
+            description: Update a specific payment by its identifier.
+            operationId: patchOrderPayment
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/order_number_path"
+                -   $ref: "#/components/parameters/payment_id_path"
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/OrderPaymentPatchable"
+            responses:
+                "200":
+                    description: Order payment details
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    payment:
+                                        $ref: "#/components/schemas/Payment"
+                "422":
+                    description: Invalid Payload (RFC7807 Problem Details)
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiProblem"
+        delete:
+            tags:
+                - Orders
+                - Payments
+            summary: Payment Remove
+            description: Remove a specific payment by its identifier.
+            operationId: deleteOrderPayment
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/order_number_path"
+                -   $ref: "#/components/parameters/payment_id_path"
+            responses:
+                "204":
+                    description: Empty Response
+    "/v{version}/orderstatuses":
+        get:
+            tags:
+                - Order statuses
+            description: Returns a listing of all available order statuses.
+            operationId: getOrderStatuses
+            security:
+                -   PartnerToken:
+                      [ ]
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+            responses:
+                "200":
+                    description: Order status list
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/OrderStatus"
+                        text/xml:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/OrderStatus"
+    "/v{version}/payment/gateways":
+        get:
+            tags:
+                - Payment Gateways
+            description: Retrieve a listing of all available payment gateways and methods
+            operationId: getGateways
+            security:
+                -   PartnerToken:
+                      [ ]
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+            responses:
+                "200":
+                    description: List of gateways
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/PaymentGateways"
+    "/v{version}/payment/stores/{store}/gateways":
+        get:
+            tags:
+                - Payment Gateways
+            description: Retrieve a listing of all payment gateways and methods available in the given store
+            operationId: getStoreGateways
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/store"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+            responses:
+                "200":
+                    description: List of gateways
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/StorePaymentGateways"
+    "/v{version}/tax-policy/regions":
+        get:
+            tags:
+                - TaxPolicyRegion
+            summary: Listing
+            description: Retrieve a list of all configured tax policy regions
+            operationId: TaxPolicyRegionList
+            parameters:
+                -   $ref: "#/components/parameters/version"
+            responses:
+                "200":
+                    description: Tax policy regions
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/TaxPolicyRegion"
+    "/v{version}/tax-policy/regions/{code}":
+        get:
+            tags:
+                - TaxPolicyRegion
+            summary: Single
+            description: Retrieve a single tax policy region by given code
+            operationId: getTaxPolicyRegion
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/region_code_path"
+            responses:
+                "200":
+                    description: Tax policy region
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    region:
+                                        $ref: "#/components/schemas/TaxPolicyRegion"
+    "/v{version}/shipping/methods":
+        get:
+            tags:
+                - Shipping methods
+            description: Returns a listing of available shipping methods for the store
+            operationId: getShippingMethods
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/format"
+            responses:
+                "200":
+                    description: List of shipping methods
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/ShippingMethod"
+                        text/xml:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/ShippingMethod"
+    "/v{version}/store":
+        get:
+            tags:
+                - Store information
+            description: Returns details for the store (identified by token)
+            operationId: getStore
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/format"
+            responses:
+                "200":
+                    description: Store details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Store"
+                        text/xml:
+                            schema:
+                                $ref: "#/components/schemas/Store"
+tags:
+    -   name: Store information
+        description: General store details
+    -   name: Orders
+        description: Order details
+    -   name: Order statuses
+        description: Available order statuses
+    -   name: Payment Gateways
+        description: Available payment gateways
+    -   name: Shipping methods
+        description: Available shipping methods
+    -   name: OfflineLocations
+        description: Point of sale location details
+    -   name: Discountcodes
+        description: Available discountcode details
+    -   name: NewsletterSubscribers
+        description: Subscriber details for the store's newsletter
+    -   name: Categories (Pages)
+        description: Page details
+    -   name: Customers
+        description: |
+            Store customer accounts.
+            ### Access
+            Due to informational sensitivity, access to these endpoints is restricted. Contact us if you'd like to make use of
+            them in your integration.
+    -   name: Articles
+        description: Article details
+    -   name: ArticleListOptions
+        description: Options for article lists
+    -   name: ArticleLists
+        description: Article (option) list details
+    -   name: ArticleFields
+        description: Custom article fields
 servers:
-  - url: https://api.myonlinestore.com/
+    -   url: https://api.myonlinestore.com/
 components:
-  parameters:
-    customer_id_path:
-      name: customerId
-      in: path
-      description: Customer Identifier
-      required: true
-      schema:
-        type: string
-        format: uuid
-    customer_address_id_path:
-      name: addressId
-      in: path
-      description: Address Identifier
-      required: true
-      schema:
-        type: string
-        format: uuid
-    order_number_path:
-      name: order_number
-      in: path
-      description: Order number
-      required: true
-      schema:
-        type: integer
-    payment_id_path:
-      name: paymentId
-      in: path
-      description: Payment Identifier
-      required: true
-      schema:
-        type: string
-        format: uuid
-    payment_embed:
-      name: embed
-      in: query
-      description: Either one or multiple (comma-separated) of "properties", "mutations", or "order"
-      required: false
-      schema:
-        type: string
-      examples:
-        order:
-          description: Include the order details of the payment
-          value: order
-        mutations:
-          description: Include the mutations of the payment
-          value: mutations
-        properties:
-          description: Include the properties of the payment
-          value: properties
-    limit:
-      name: limit
-      in: query
-      description: "Maximum number of items to return (max: 100)"
-      required: false
-      schema:
-        type: integer
-        maximum: 100
-        default: 10
-    offset:
-      name: offset
-      in: query
-      description: Number of items to skip
-      required: false
-      schema:
-        type: integer
-    start_date:
-      name: start_date
-      in: query
-      description: Minimum date value
-      required: false
-      schema:
-        type: string
-        format: date
-    end_date:
-      name: end_date
-      in: query
-      description: Maximum date value
-      required: false
-      schema:
-        type: string
-        format: date
-    version:
-      name: version
-      in: path
-      required: true
-      schema:
-        type: string
-        enum:
-          - "1"
-          - "2-beta"
-        default: "1"
-    region_code_path:
-      name: code
-      in: path
-      description: Region code (ISO 3166-1 alpha-2)
-      required: true
-      schema:
-        type: string
-        pattern: '^[A-Z]{2}$'
-    language:
-      name: language
-      in: query
-      description: Shop language to return content for
-      required: false
-      schema:
-        type: string
-        enum:
-          - nl_NL
-          - en_GB
-          - de_DE
-          - fr_FR
-          - es_ES
-          - en_US
-          - pt_PT
-          - it_IT
-          - da_DK
-          - sv_SE
-          - no_NO
-          - tr_TR
-          - pl_PL
-        default: nl_NL
-    format:
-      name: format
-      in: query
-      description: Response format
-      required: false
-      schema:
-        type: string
-        enum:
-          - json
-          - xml
-        default: json
-    archived:
-      name: archived
-      in: query
-      description: Archived status
-      required: false
-      schema:
-        type: boolean
-    status_id:
-      name: status_id
-      in: query
-      description: Only include orders with specific status
-      required: false
-      schema:
-        type: integer
-    status_changed_start_date:
-      name: status_changed_start_date
-      in: query
-      description: "Minimum for status changed datetime (format: yyyy-mm-dd hh:mm:ss)"
-      required: false
-      schema:
-        type: string
-        format: date-time
-    status_changed_end_date:
-      name: status_changed_end_date
-      in: query
-      description: "Maximum for status changed datetime (format: yyyy-mm-dd hh:mm:ss)"
-      required: false
-      schema:
-        type: string
-        format: date-time
-    debtor_email:
-      name: debtor_email
-      in: query
-      description: |
-        Filter results on the e-mail address of the debtor. Uses an `OR` condition when
-        combined with `debtor_id`.
-      required: false
-      schema:
-        type: string
-    debtor_id:
-      name: debtor_id
-      in: query
-      description: |
-        Filter results on the ID of the debtor. Uses an `OR` condition when
-        combined with `debtor_email`.
-      required: false
-      schema:
-        type: string
-        format: uuid
-    store:
-      name: store
-      in: path
-      description: The store's UUID or `me` alias to retrieve the store from the access token
-      required: true
-      schema:
-        type: string
-    created_start_date:
-      name: created_start_date
-      in: query
-      description: "Minimum for created datetime (format: yyyy-mm-dd hh:mm:ss)"
-      required: false
-      schema:
-        type: string
-        format: date-time
-    created_end_date:
-      name: created_end_date
-      in: query
-      description: "Maximum for created datetime (format: yyyy-mm-dd hh:mm:ss)"
-      required: false
-      schema:
-        type: string
-        format: date-time
-    changed_start_date:
-      name: changed_start_date
-      in: query
-      description: "Minimum for changed datetime (format: yyyy-mm-dd hh:mm:ss)"
-      required: false
-      schema:
-        type: string
-        format: date-time
-    changed_end_date:
-      name: changed_end_date
-      in: query
-      description: "Maximum for changed datetime (format: yyyy-mm-dd hh:mm:ss)"
-      required: false
-      schema:
-        type: string
-        format: date-time
-    use_url_id:
-      name: use_url_id
-      in: query
-      description: Enable this when article_id equals the ID from article page URLs
-      required: true
-      schema:
-        type: boolean
-        default: false
-    activated:
-      name: activated
-      in: query
-      description: Filter on activated (confirmed) subscriptions
-      required: false
-      schema:
-        type: boolean
-    activate:
-      name: activate
-      in: query
-      description: Activation email should be send to subscriber (if not already activated)
-      required: false
-      schema:
-        type: boolean
-        default: false
-    ids:
-      name: ids
-      in: query
-      description: Only include products with specific ids
-      required: false
-      schema:
-        type: array
-        items:
-          type: integer
-    uuids:
-      name: uuids
-      in: query
-      description: Only include products with specific UUID's
-      required: false
-      schema:
-        type: array
-        items:
-          type: string
-          format: uuid
-    test:
-      name: test
-      in: query
-      description: Include test orders in the response
-      required: false
-      schema:
-        type: boolean
-        default: false
-  requestBodies:
-    postArticleListsLists:
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              type: integer
-      description: List Ids
-      required: true
-  securitySchemes:
-    StoreToken:
-      description: The merchant may create a token to give your application access to their data.
-        This can be done from the shop backend through **Settings --> API --> Add new token**. This token should be kept secret.
-      type: apiKey
-      in: query
-      name: token
-    PartnerToken:
-      description: This token can be obtained by [registering](https://www.mijnwebwinkel.nl/contact) your (intended) application.
-        This token should be kept secret.
-      type: apiKey
-      in: query
-      name: partner_token
-  schemas:
-    Address:
-      description: Generic address
-      required:
-        - name
-        - zipcode
-      properties:
-        id:
-          description: Address UUID. No other address field is required if an ID is
-            provided.
-          type: string
-        gender:
-          description: Gender description
-          type: string
-        name:
-          description: Full name
-          type: string
-        company:
-          description: Company name
-          type: string
-        phone:
-          description: Phone number
-          type: string
-        street:
-          description: Street name
-          type: string
-        number:
-          description: Housenumber
-          type: string
-        zipcode:
-          type: string
-        city:
-          type: string
-        country:
-          deprecated: true
-          description: (Localized) country name
-          type: string
-        country_code:
-          description: ISO 3166-1 alpha-2 country code
-          type: string
-    Article:
-      required:
-        - name
-        - categories
-      example:
-        id: 123
-        uuid: "095be615-a8ad-4c33-8e9c-c7612fbf6c9f"
-        name: Funny cushion
-        description: Endless fun
-        sku: ART758379-L
-        badge_text: van - voor
-        taxable: true
-        price:
-          default: 12.5
-          action: 9.95
-          purchase: 8.95
-        created_date: "2016-07-04"
-        created_time: "09:11:25"
-        updated_date: "2016-07-25"
-        updated_time: "11:16:59"
-        stock: 15
-        delivery_days: 5
-        meta_title: "Funny shop: Funny Cushion"
-        meta_description: Awesome description here
-        can_backorder: false
-        extra:
-          invisible:
-            weight: "0.25"
-            barcode: "8712345678906"
-          visible:
-            Fart power (Beaufort): "5"
-        url: https://myonline.store/a-245/the-best-balloon-animals-for-your-party/funny-cushion
-        categories:
-          - category_id: 748020
-            article_url_id: 245
-            is_active: true
-            is_main: true
-        lists:
-          - id: 193177
-            name: Sounds
-            description: Special laugh sounds
-            has_images: true
-            options:
-              - id: 71362
-                name: Jim Carrey
-                price: "99.00"
-                image_ids:
-                  - 7e2009bf-f4a6-4f6d-9874-14ed1341229b
-              - id: 71363
-                name: Clown
-                price: "5.00"
-        variants:
-          - id: 1362
-            options:
-              "193177": Jim Carrey
-            stock: 3
-        images:
-          - position: 2
-            id: 7e2009bf-f4a6-4f6d-9874-14ed1341229b
-            original_name: "my_uploaded_image"
-            urls:
-              full: https://asset.myonlinestore.com/winkel/winkelnaam/images/full/b1787d2f15742a7d9c869f186b948ddbc2faecb87
-              article: https://asset.myonlinestore.com/winkel/winkelnaam/images/article/b1787d2f15742a7d9c869f186b948ddbc2faecb87
-              thumb: https://asset.myonlinestore.com/winkel/winkelnaam/images/thumb/b1787d2f15742a7d9c869f186b948ddbc2faecb87
-      allOf:
-        - $ref: "#/components/schemas/BaseArticle"
-        - properties:
-            id:
-              description: "Internal article ID (deprecated: use `uuid` instead)"
-              type: integer
-              deprecated: true
-            uuid:
-              description: Article UUID
-            created_date:
-              description: Creation date
-              type: string
-              format: date
-            created_time:
-              description: Creation time
-              type: string
-              format: time
-            updated_date:
-              description: Last updated date
-              type: string
-              format: date
-            updated_time:
-              description: Last updated time
-              type: string
-              format: time
-            can_backorder:
-              description: Available for purchase if sold out (see also delivery_days)
-              type: boolean
-            categories:
-              description: Pages the article is shown on
-              type: array
-              items:
-                $ref: "#/components/schemas/CategoryArticle"
-            lists:
-              description: Choices offered for the article
-              type: array
-              items:
-                $ref: "#/components/schemas/ConfiguratorArticleList"
-            images:
-              type: array
-              items:
-                $ref: "#/components/schemas/ArticleImage"
-            variants:
-              description: Versions of the article which have at least one diverging field value
-              type: array
-              items:
-                $ref: "#/components/schemas/ArticleVariant"
-    ArticlePatchable:
-      example:
-        name: Funny cushion
-        description: Endless fun
-        sku: ART758379-L
-        badge_text: van - voor
-        taxable: true
-        price:
-          default: 12.5
-          action: 9.95
-          purchase: 8.95
-        stock: 15
-        delivery_days: 5
-        meta_title: "Funny shop: Funny Cushion"
-        meta_description: Awesome description here
-        can_backorder: false
-        extra:
-          invisible:
-            weight: "0.25"
-            barcode: "8712345678906"
-          visible:
-            Fart power (Beaufort): "5"
-        categories:
-          - category_id: 748020
-            is_main: true
-            is_active: true
-          - category_id: 824312
-            article_url_id: 4005
-            is_main: false
-            is_active: true
-        lists:
-          - id: 293822
-            has_images: true
-            options:
-              - id: 1690460
-                image_ids:
-                  - 8fc37dbc-3704-4807-bb75-3e1917b5326d
-              - id: 1991624
-                image_ids:
-                  - 8fc37dbc-3704-4807-bb75-3e1917b5326d
-                  - 7e2009bf-f4a6-4f6d-9874-14ed1341229b
-        variants:
-          - id: 1362
-            stock: 27
-        images:
-          - id: 7e2009bf-f4a6-4f6d-9874-14ed1341229b
-            url: https://myonlineimage.com/my-image-1.jpg
-            position: 1
-          - id: 8fc37dbc-3704-4807-bb75-3e1917b5326d
-            url: https://myonlineimage.com/my-image-2.jpg
-            position: 2
-      allOf:
-        - $ref: "#/components/schemas/ArticlePostable"
-        - properties:
-            categories:
-              type: array
-              items:
-                $ref: "#/components/schemas/CategoryArticlePatchable"
-            variants:
-              type: array
-              items:
-                $ref: "#/components/schemas/ArticleVariant"
-    ArticlePostable:
-      example:
-        name: Funny cushion
-        description: Endless fun
-        sku: ART758379-L
-        badge_text: van - voor
-        taxable: true
-        price:
-          default: 12.5
-          action: 9.95
-          purchase: 8.95
-        stock: 15
-        delivery_days: 5
-        meta_title: "Funny shop: Funny Cushion"
-        meta_description: Awesome description here
-        can_backorder: false
-        extra:
-          invisible:
-            weight: "0.25"
-            barcode: "8712345678906"
-          visible:
-            Fart power (Beaufort): "5"
-        categories:
-          - category_id: 748020
-            is_main: true
-            is_active: true
-        lists:
-          - id: 293822
-            has_images: true
-            options:
-              - id: 1690460
-                image_ids:
-                  - 8fc37dbc-3704-4807-bb75-3e1917b5326d
-              - id: 1991624
-                image_ids:
-                  - 8fc37dbc-3704-4807-bb75-3e1917b5326d
-                  - 7e2009bf-f4a6-4f6d-9874-14ed1341229b
-        images:
-          - id: 7e2009bf-f4a6-4f6d-9874-14ed1341229b
-            url: https://myonlineimage.com/my-image-1.jpg
-            position: 1
-          - id: 8fc37dbc-3704-4807-bb75-3e1917b5326d
-            url: https://myonlineimage.com/my-image-2.jpg
-            position: 2
-      allOf:
-        - $ref: "#/components/schemas/BaseArticle"
-        - properties:
-            categories:
-              type: array
-              items:
-                $ref: "#/components/schemas/CategoryArticlePostable"
-            lists:
-              type: array
-              items:
-                $ref: "#/components/schemas/ConfiguratorArticleListPostable"
-            images:
-              type: array
-              items:
-                $ref: "#/components/schemas/ArticleImagePostable"
-    ArticleUploadImagePostable:
-      properties:
-        filename:
-          type: string
-        position:
-          type: integer
-        content:
-          type: string
-          format: base64
-    BaseArticle:
-      properties:
-        name:
-          description: Name of the article
-          type: string
-        description:
-          description: Description for this article
-          type: string
-        sku:
-          description: Stock keeping unit
-          type: string
-        badge_text:
-          description: Additional text shown as badge
-          type: string
-        taxable:
-          description: Whether tax is charged when the article is sold
-          type: boolean
-        price:
-          $ref: "#/components/schemas/ArticlePrice"
-        stock:
-          description: Number in stock (specify null for unlimited stock)
-          type: integer
-        delivery_days:
-          description: Delivery time (in days) if the article is sold out (see also can_backorder)
-          type: integer
-        meta_title:
-          description: Metadata title
-          type: string
-        meta_description:
-          description: Metadata description
-          type: string
-        extra:
-          $ref: "#/components/schemas/ArticleExtraFieldSet"
-    ArticleLimited:
-      properties:
-        id:
-          description: Internal article id
-          type: integer
-        name:
-          description: Name of the article
-          type: string
-        uuid:
-          description: UUID of the article
-          type: string
-          format: uuid
-        is_main:
-          description: Whether this is the primary category linked to the article
-          type: boolean
-    ArticleExtraFieldSet:
-      properties:
-        visible:
-          { }
-        invisible:
-          { }
-    ArticleImage:
-      properties:
-        position:
-          type: string
-        id:
-          type: string
-          format: uuid
-        original_name:
-          description: Base name of the originally uploaded file
-          type: string
-        url:
-          deprecated: true
-          type: string
-        urls:
-          description: image url's for all formats
-          type: array
-          items:
-            $ref: "#/components/schemas/ArticleImageUrl"
-    ArticleImageUrl:
-      type: object
-      additionalProperties:
-        type: string
-    ArticleImagePostable:
-      properties:
-        id:
-          type: string
-          format: uuid
-        position:
-          type: integer
-        url:
-          type: string
-    ArticleList:
-      properties:
-        id:
-          description: Internal article list id
-          type: integer
-        name:
-          type: string
-        description:
-          type: string
-        options:
-          type: array
-          items:
-            $ref: "#/components/schemas/ArticleListOption"
-      example:
-        name: Sounds
-        description: Special laugh sounds
-        options:
-          - name: Jim Carrey
-            price: "99.00"
-          - name: Clown
-            price: "5.00"
-    ArticleListOption:
-      properties:
-        id:
-          type: integer
-        name:
-          type: string
-        price:
-          type: string
-    ConfiguratorArticleList:
-      example:
-        name: Sounds
-        description: Special laugh sounds
-        has_images: true
-        options:
-          - name: Jim Carrey
-            price: "99.00"
-            image_ids:
-              - 1d29d35a-f8ef-404f-923a-cd08d8578909
-          - name: Clown
-            price: "5.00"
-      properties:
-        has_images:
-          type: boolean
-          description: Whether the ConfiguratorArticleList has images enabled
-        options:
-          type: array
-          items:
-            $ref: "#/components/schemas/ConfiguratorArticleListOption"
-      allOf:
-        - $ref: "#/components/schemas/ArticleList"
-    ConfiguratorArticleListPostable:
-      required:
-        - id
-        - options
-      properties:
-        id:
-          type: integer
-          description: ArticleList id
-        has_images:
-          type: boolean
-          description: Whether the ConfiguratorArticleList has images enabled. This may be
-            true for only 1 entry per article
-        options:
-          type: array
-          items:
-            $ref: "#/components/schemas/ConfiguratorArticleListOptionPostable"
-    ConfiguratorArticleListOption:
-      properties:
-        image_ids:
-          type: array
-          items:
-            type: string
-            format: uuid
-            description: ArticleImage
-      allOf:
-        - $ref: "#/components/schemas/ArticleListOption"
-    ConfiguratorArticleListOptionPostable:
-      required:
-        - id
-        - image_ids
-      properties:
-        id:
-          type: integer
-          description: ArticleListOption id
-        image_ids:
-          type: array
-          items:
-            type: string
-            format: uuid
-            description: ArticleImage
-    ArticlePrice:
-      properties:
-        default:
-          description: The default price for which the product is offered (incl. tax depending on the value of [`store.prices_include_tax`](#tag/Store-information))
-          type: string
-        action:
-          description: The discounted price; overrides the default offer (incl. tax depending on the value of [`store.prices_include_tax`](#tag/Store-information))
-          type: string
-        purchase:
-          description: The purchase price (excl. tax)
-          type: string
-    ArticleVariant:
-      properties:
-        id:
-          description: Internal article variant id
-          type: integer
-        options:
-          description: Selected options
-          type: array
-          items:
-            $ref: "#/components/schemas/ArticleVariantOption"
-        stock:
-          type: integer
-        can_backorder:
-          type: boolean
-    ArticleVariantOption:
-      properties:
-        list_id:
-          type: integer
-        option_id:
-          type: integer
-        name:
-          type: string
-    Category:
-      properties:
-        id:
-          description: Category identifier
-          type: integer
-        parent_category_id:
-          description: ID of the parent category
-          type: integer
-        hidden:
-          description: Is the page hidden in the store
-          type: boolean
-        title:
-          description: Category page title
-          type: string
-        content:
-          description: Category page content
-          type: string
-        meta_title:
-          description: Metadata page title
-          type: string
-        meta_description:
-          description: Metadata page description
-          type: string
-        article_order:
-          description: |-
-            Order in which products are shown on this page:
-            1: price, ascending
-            2: name, ascending
-            3: last edited date, descending
-            4: created date, descending
-            5: manually defined, new products added at the bottom
-            6: manually defined, new products added at the top
-          type: integer
-        leafs:
-          type: array
-          items:
-            $ref: "#/components/schemas/Category"
-        sorting:
-          $ref: "#/components/schemas/CategorySorting"
-      example:
-        id: 78909
-        parent_category_id: 8569
-        hidden: false
-        title: The best balloon animals for your party
-        content: Balloon animals are great, don't you think?
-        meta_title: Balloon animals
-        meta_description: The best balloon animals for your party
-        article_order: 5
-        leafs:
-          - id: 78910
-            parent_id: 78909
-            hidden: true
-            title: New collection
-        sorting:
-          first: false
-          last: false
-          previous: 78908
-          next: 78910
-    CategoryPostable:
-      required:
-        - title
-      example:
-        parent_category_id: 8569
-        hidden: false
-        title: The best balloon animals for your party
-        content: Balloon animals are great, don't you think?
-        meta_title: Balloon animals
-        meta_description: The best balloon animals for your party
-        article_order: 6
-        sorting:
-          before: 78908
-      allOf:
-        - $ref: "#/components/schemas/CategoryPatchable"
-    CategoryPatchable:
-      properties:
-        parent_category_id:
-          description: ID of the parent category
-          type: integer
-        hidden:
-          description: Is the page hidden in the store
-          type: boolean
-        title:
-          description: Category page title
-          type: string
-        content:
-          description: Category page content
-          type: string
-        meta_title:
-          description: Metadata page title
-          type: string
-        meta_description:
-          description: Metadata page description
-          type: string
-        article_order:
-          description: |-
-            Order in which products are shown on this page:
-            1: price, ascending
-            2: name, ascending
-            3: last edited date, descending
-            4: created date, descending
-            5: manually defined
-          type: integer
-        sorting:
-          $ref: "#/components/schemas/CategorySortingPostable"
-      example:
-        parent_category_id: 8569
-        hidden: false
-        title: The best balloon animals for your party
-        content: Balloon animals are great, don't you think?
-        meta_title: Balloon animals
-        meta_description: The best balloon animals for your party
-        article_order: 5
-        sorting:
-          before: 78908
-    CategoryArticle:
-      properties:
-        position:
-          description: Relative position of the article on the page
-          type: integer
-      allOf:
-        - $ref: "#/components/schemas/CategoryArticlePatchable"
-    CategoryArticlePatchable:
-      properties:
-        article_url_id:
-          description: Unique ID of the article linked to this page
-          type: integer
-      allOf:
-        - $ref: "#/components/schemas/CategoryArticlePostable"
-    CategoryArticlePostable:
-      required:
-        - category_id
-      properties:
-        category_id:
-          description: Internal category id
-          type: integer
-        is_active:
-          description: Whether the article is visible in the store on this page
-          type: boolean
-        is_main:
-          description: Whether this is the primary category linked to the article
-          type: boolean
-    CategorySorting:
-      description: Category sorting details
-      properties:
-        first:
-          description: Is this category the first of it's branch?
-          type: boolean
-        last:
-          description: Is this category the last of it's branch?
-          type: boolean
-        previous:
-          description: ID of the previous category, if any
-          type: integer
-        next:
-          description: ID of the next category, if any
-          type: integer
-    CategorySortingPostable:
-      description: Category sorting details
-      properties:
-        first:
-          description: True if this category should be the first of it's branch
-          type: boolean
-        last:
-          description: True if this category should be the last of it's branch (default
-            behavior)
-          type: boolean
-        before:
-          description: ID of the category this category should be placed after
-          type: integer
-        after:
-          description: ID of the category this category should be placed before
-          type: integer
-    CountResponse:
-      description: Response of a count operation
-      properties:
-        count:
-          description: The number of matching items
-          type: integer
-    Customer:
-      description: Customer
-      properties:
-        id:
-          description: Customer identifier
-          type: string
-          format: uuid
-        storeId:
-          description: Store identifier that this customer belongs to
-          type: string
-          format: uuid
-        email:
-          description: Email address
-          type: string
-          format: email
-        firstName:
-          description: First name
-          type: string
-          nullable: true
-        lastName:
-          description: Last name
-          type: string
-          nullable: true
-        dateOfBirth:
-          description: Date of birth (yyyy-mm-dd)
-          type: string
-          nullable: true
-          format: date
-        description:
-          description: Information about the customer added by the merchant
-          type: string
-          nullable: true
-        addresses:
-          description: Addresses for this customers
-          type: array
-          items:
-            $ref: '#/components/schemas/CustomerAddress'
-    CustomerPatchable:
-      description: Customer Update Body
-      properties:
-        firstName:
-          description: First name
-          type: string
-          nullable: true
-        lastName:
-          description: Last name
-          type: string
-          nullable: true
-        dateOfBirth:
-          description: Date of birth (yyyy-mm-dd)
-          type: string
-          nullable: true
-          format: date
-        description:
-          description: Information about the customer added by the merchant
-          type: string
-          nullable: true
-    CustomerAddress:
-      description: Customer Address
-      properties:
-        id:
-          description: Address identifier
-          type: string
-          format: uuid
-        firstName:
-          description: First name
-          type: string
-        lastName:
-          description: Last name
-          type: string
-        street:
-          description: Street name
-          type: string
-        streetNumber:
-          description: Street number (may include suffix)
-          type: string
-        zipCode:
-          description: Zip code
-          type: string
-        city:
-          description: City
-          type: string
-        countryCode:
-          description: ISO 3166-1 alpha-2 country code
-          type: string
-          pattern: '^[A-Z]{2}$'
-        company:
-          description: Company name
-          type: string
-          nullable: true
-        gender:
-          description: Gender
-          type: string
-          nullable: true
-          enum:
-            - F
-            - M
-        phone:
-          description: Phone number
-          type: string
-          nullable: true
-        taxNumber:
-          description: Vat reference number
-          type: string
-          nullable: true
-        iban:
-          description: International Bank Account Number
-          type: string
-          format: iban
-          nullable: true
-        isDefaultForDelivery:
-          description: Whether this address should be used as delivery address by default
-          type: boolean
-        isDefaultForInvoice:
-          description: Whether this address should be used as invoice address by default
-          type: boolean
-    CustomerAddressPatchable:
-      description: Customer Address
-      properties:
-        firstName:
-          description: First name
-          type: string
-        lastName:
-          description: Last name
-          type: string
-        street:
-          description: Street name
-          type: string
-        streetNumber:
-          description: Street number (may include suffix)
-          type: string
-        zipCode:
-          description: Zip code
-          type: string
-        city:
-          description: City
-          type: string
-        countryCode:
-          description: ISO 3166-1 alpha-2 country code
-          type: string
-          pattern: '^[A-Z]{2}$'
-        company:
-          description: Company name
-          type: string
-          nullable: true
-        gender:
-          description: Gender
-          type: string
-          nullable: true
-          enum:
-            - F
-            - M
-        phone:
-          description: Phone number
-          type: string
-          nullable: true
-        taxNumber:
-          description: Vat reference number
-          type: string
-          nullable: true
-        iban:
-          description: International Bank Account Number
-          type: string
-          format: iban
-          nullable: true
-        isDefaultForDelivery:
-          description: Whether this address should be used as delivery address by default
-          type: boolean
-        isDefaultForInvoice:
-          description: Whether this address should be used as invoice address by default
-          type: boolean
-    CustomerAddressPostable:
-      description: Customer Address
-      properties:
-        firstName:
-          description: First name
-          type: string
-        lastName:
-          description: Last name
-          type: string
-        street:
-          description: Street name
-          type: string
-        streetNumber:
-          description: Street number (may include suffix)
-          type: string
-        zipCode:
-          description: Zip code
-          type: string
-        city:
-          description: City
-          type: string
-        countryCode:
-          description: ISO 3166-1 alpha-2 country code
-          type: string
-          pattern: '^[A-Z]{2}$'
-        company:
-          description: Company name
-          type: string
-          nullable: true
-        gender:
-          description: Gender
-          type: string
-          nullable: true
-          enum:
-            - F
-            - M
-        phone:
-          description: Phone number
-          type: string
-          nullable: true
-        taxNumber:
-          description: Vat reference number
-          type: string
-          nullable: true
-        iban:
-          description: International Bank Account Number
-          type: string
-          format: iban
-          nullable: true
-    InvoiceAddress:
-      description: Invoice address
-      allOf:
-        - $ref: "#/components/schemas/Address"
-        - properties:
-            taxnumber:
-              description: Vat reference number
-              type: string
-            bankaccount:
-              description: Bankaccount number
-              type: string
-    Order:
-      required:
-        - number
-        - uuid
-        - date
-        - time
-        - status
-        - debtor
-      properties:
-        number:
-          description: Ordernumber
-          type: integer
-        uuid:
-          description: Order UUID
-          type: string
-          format: uuid
-        date:
-          description: Order date
-          type: string
-          format: date
-        time:
-          description: Order time
-          type: string
-        status:
-          description: Order status
-          type: integer
-        status_changed_date:
-          description: Date of last status change
-          type: string
-          format: date
-        status_changed_time:
-          description: Time of last status change
-          type: string
-        weight:
-          description: Total order weight
-          type: string
-        archived:
-          description: Archived status
-          type: boolean
-        finished:
-          deprecated: true
-          description: "Finished status (deprecated: always true)"
-          type: boolean
-        taxed:
-          description: VAT added
-          type: string
-        locale:
-          description: Order localisation
-          type: string
-        discountcode:
-          description: Discountcode
-          type: string
-        currency:
-          description: Chosen currency (ISO 4217 code)
-          type: string
-        currency_format_locale:
-          description: Chosen currency format locale (ISO 3166-1 alpha-2 code)
-          type: string
-        credited_order_number:
-          description: Reference to the original order for which this is a credit order
-          type: integer
-        credit_order_numbers:
-          description: Ordernumbers of any linked credit orders
-        comments:
-          $ref: "#/components/schemas/OrderComment"
-        business_model:
-          description: Which business model has been applied to the order.
-            In this case the `company` field will not be empty and the `reference` field is available
-          type: string
-          enum:
-            - B2C
-            - B2B
-        reference:
-          description: Order reference for business sales. Only available if business model is `B2B`
-          type: string
-          maxLength: 255
-        tax_region:
-          description: The region that has been used for tax calculations (ISO 3166-1 alpha-2)
-          type: string
-          pattern: '^[A-Z]{2}$'
-        tax_strategy:
-          description: Which tax strategy (if any) has been applied to this order
-          type: string
-          enum:
-            - ''
-            - zero_percent
-            - reverse_charged_vat
-        partner:
-          type: object
-          properties:
-            name:
-              description: Partner name
-              type: string
-        payment_status:
-          type: string
-          deprecated: true
-          description: Current payment status (`new` |`pending` |
-            `authorized` | `captured` | `voided` | `refunded` |
-            `failed` | `incomplete` | `unknown`)
-            (deprecated in favor of the order payment listing endpoint)
-        payment:
-          $ref: "#/components/schemas/OrderPaymentSummary"
-        debtor:
-          $ref: "#/components/schemas/OrderDebtor"
-        price:
-          type: object
-          properties:
-            tax:
-              description: Amount of applied VAT
-              oneOf:
-                - type: array
-                  items:
-                    $ref: "#/components/schemas/TaxPrice"
-                - $ref: "#/components/schemas/TaxPrice"
-            total:
-              description: Total price (including VAT)
-              type: string
-        orderlines:
-          type: array
-          items:
-            $ref: "#/components/schemas/OrderDetail"
-        shipping:
-          type: array
-          items:
-            $ref: "#/components/schemas/OrderShipping"
-      example:
-        number: 27
-        uuid: "af88e19b-a57b-4aae-a92b-f7078454d1e3"
-        date: "2015-11-03"
-        time: "13:37:12"
-        status: 1
-        archived: true
-        finished: false
-        taxed: include
-        locale: en_GB
-        discountcode: korting123
-        comments:
-          customer: Please send quickly!
-        business_model: B2B
-        reference: MOS103271
-        offline_location_id: 7127e08a-4af0-4fdf-ac7b-157be3345df0
-        currency: EUR
-        credited_order_number: 28
-        credit_order_numbers:
-          - 99
-          - 101
-        payment:
-          gateway_name: "basic"
-          method_name: "advance"
-        payment_status: captured
-        debtor:
-          email: support@mijnwebwinkel.nl
-          address:
-            invoice:
-              gender: V
-              name: Truus voorbeeldig
-              company: Voorbeeldig BV
-              street: Molenstraat
-              number: "62"
-              zipcode: 5341GE
-              city: Oss
-              country: Nederland
-              country_code: NL
-              phone: 06-12345678
-              bankaccount: NL39RABO0300065264
-        price:
-          tax:
-            - amount: 0.830000
-              rate: 9.00
-            - amount: 6.500000
-              rate: 21.00
-          total: 47.450000
-        orderlines:
-          - id: 8140cf8f-0ef1-4e71-aed0-dc3efc1b46b3
-            type: article
-            quantity: 1
-            weight: 0
-            description: Article A
-            price:
-              amount: 12.396694
-              amount_including_tax: 15.00
-              rate: 21.00
-            articles:
-              - id: 1
-                description: Article A
-                price:
-                  amount: 24.793388
-                  rate: 21.00
-                options:
-                  - description: Action price
-                    price:
-                      amount: -12.396694
-                      rate: 21.00
-          - id: 19bc3d68-eea1-41ac-9743-3b1ba58aa5ac
-            type: article
-            quantity: 2
-            weight: 0
-            description: Article B
-            price:
-              amount: 8.181818
-              amount_including_tax: 9.90
-              rate: 21.00
-            articles:
-              - id: 2
-                description: Article B
-                price:
-                  amount: 7.396694
-                  rate: 21.00
-                options:
-                  - description: Action price
-                    price:
-                      amount: -3.305785
-                      rate: 21.00
-          - id: 07d24f67-0f98-414d-9dba-61814a09964d
-            type: article
-            quantity: 3
-            weight: 0
-            description: Article C
-            price:
-              amount: 4.834710
-              amount_including_tax: 5.85
-              rate: 21.00
-              articles:
-                - id: 3
-                  description: Article C
-                  price:
-                    amount: 1.611570
-                    rate: 21.00
-          - id: 155a7fae-6f09-4444-9bdb-87cf03a7fa1d
-            type: article
-            quantity: 5
-            weight: 0
-            description: Article D
-            price:
-              amount: 8.944950
-              amount_including_tax: 9.75
-              rate: 9.00
-            articles:
-              - id: 4
-                description: Article D
-                price:
-                  amount: 1.788990
-                  rate: 9.00
-          - id: d2f57281-7c24-4fd8-b000-caeb3da639db
-            type: payment
-            quantity: 1
-            price:
-              - amount: 0.192571
-                rate: 9.00
-                amount_including_tax: 0.21
-              - amount: 0.652972
-                rate: 21.00
-                amount_including_tax: 0.79
-          - id: 2fed4cd8-4ad1-440c-9d27-6fb32d2e0eba
-            type: payment
-            quantity: 1
-            price:
-              amount: 4.917355
-              amount_including_tax: 5.95
-              rate: 21.00
-        shipping:
-          - country:
-              description: Nederland
-              isocode: NL
-    OrderPatchable:
-      properties:
-        archived:
-          description: Archived status
-          type: boolean
-        status:
-          description: Order status
-          type: integer
-        comments:
-          $ref: "#/components/schemas/OrderCommentPatchable"
-        reference:
-          description: Order reference for business sales. Only available if business model is `B2B`
-          type: string
-          maxLength: 255
-        offline_location_id:
-          description: Point of Sale location identifier (Contains null for direct webshop
-            orders)
-          type: string
-      example:
-        status: 1
-        archived: true
-        comments:
-          internal: Owner's commentary
-        reference: MOS1044712
-        offline_location_id: 7127e08a-4af0-4fdf-ac7b-157be3345df0
-    OrderPostable:
-      required:
-        - orderlines
-        - debtor
-      example:
-        status: 1
-        archived: false
-        discountcode: korting123
-        comments:
-          customer: Please send quickly!
-        business_model: B2C
-        offline_location_id: 7127e08a-4af0-4fdf-ac7b-157be3345df0
-        payment:
-          gateway_name: mollie
-          method_name: ideal
-          status:
-            id: 1
-        debtor:
-          email: support@mijnwebwinkel.nl
-          address:
-            invoice:
-              gender: V
-              name: Truus voorbeeldig
-              company: ""
-              street: Molenstraat
-              number: "62"
-              zipcode: 5341GE
-              city: Oss
-              country_code: NL
-              phone: 06-12345678
-              bankaccount: NL39RABO0300065264
-        orderlines:
-          - type: article
-            quantity: 3
-            articles:
-              - id: 3327557
-                options:
-                  - list_option_id: "1537892"
-                  - list_option_id: "1538895"
-          - type: article
-            quantity: 1
-            articles:
-              - id: 3327558
-            price_override: "13.99"
-          - type: custom
-            quantity: 2
-            description: Omg I'm só special
-            unit_price:
-              amount: "8.223140"
-              rate: "21.00"
-            unit_weight: "2.2"
-          - type: custom
-            quantity: 1
-            description: I'm special and have a unit price specified including vat
-            unit_price:
-              amount_including_tax: "5.95"
-              rate: "21.00"
-            unit_weight: "2.2"
-        shipping_method_id: "2273"
-      allOf:
-        - $ref: "#/components/schemas/OrderPatchable"
-        - properties:
-            discountcode:
-              description: Discountcode
-              type: string
-            business_model:
-              description: Which business model should be applied to the order. For `B2B` the
-                `OrderDebtor.address.invoice.company` field must not be empty. For `B2C` the `reference` field is not
-                available. If this field is omitted the value of `Store.available_business_models` will be used,
-                defaulting to `B2C` if this setting is `ALL`. If `Store.available_business_models` equals `B2B`,
-                the `company` field must not be empty.
-              type: string
-              enum:
-                - B2C
-                - B2B
-              default: B2C
-            reference:
-              description: Order reference for business sales. Only available if business model is `B2B`
-              type: string
-              maxLength: 255
-            debtor:
-              $ref: "#/components/schemas/OrderDebtor"
-            payment:
-              $ref: "#/components/schemas/OrderPaymentSummary"
-            orderlines:
-              type: array
-              items:
-                $ref: "#/components/schemas/OrderDetailPostable"
-            shipping_method_id:
-              description: Shipping method reference
-              type: string
-            shipping_type:
-              description: This defines the shipping type for the order. The order will be identified as delivery or pickup order based on this status. 1 delivery_none, 2 delivery_by_weight, 3 - delivery_by_weight_and_country, 5 - pickup_at_location, 6 - pickup_at_store, 7 - delivery_moment, 8 - delivery_no_costs
-              type: integer
-              enum:
-                - 1
-                - 2
-                - 3
-                - 5
-                - 6
-                - 7
-                - 8
-              default: 1
-    OrderAddress:
-      required:
-        - invoice
-      properties:
-        invoice:
-          $ref: "#/components/schemas/InvoiceAddress"
-        delivery:
-          $ref: "#/components/schemas/Address"
-    OrderArticle:
-      allOf:
-        - $ref: "#/components/schemas/OrderArticlePostable"
-        - required:
-            - rate
-            - amount
-        - properties:
-            description:
-              description: Article description
-              type: string
-            sku:
-              description: Article SKU
-              type: string
-            price:
-              type: object
-              properties:
-                amount:
-                  description: Amount (excluding tax), may have up to 6 decimals
-                  type: string
-                rate:
-                  description: Tax percentage
-                  type: string
-                purchase_price:
-                  description: Cost of the article for the merchant, if specified
-                  type: string
-            options:
-              type: array
-              items:
-                $ref: "#/components/schemas/OrderArticleListOption"
-    OrderArticlePostable:
-      required:
-        - id
-      allOf:
-        - $ref: "#/components/schemas/BaseOrderArticle"
-        - properties:
-            options:
-              type: array
-              items:
-                $ref: "#/components/schemas/OrderArticleListOptionPostable"
-    BaseOrderArticle:
-      properties:
-        id:
-          description: Internal article id
-          type: integer
-    OrderArticleDetail:
-      properties:
-        description:
-          description: Option description
-          type: string
-        price:
-          $ref: "#/components/schemas/TaxPrice"
-    OrderArticleListOption:
-      allOf:
-        - $ref: "#/components/schemas/OrderArticleListOptionPostable"
-        - properties:
-            description:
-              type: string
-            price:
-              type: string
-    OrderArticleListOptionPostable:
-      required:
-        - list_option_id
-      properties:
-        list_option_id:
-          type: integer
-    OrderComment:
-      properties:
-        customer:
-          description: Comment as added by customer
-          type: string
-          readOnly: true
-        internal:
-          description: Comment as added by merchant
-          type: string
-    OrderCommentPatchable:
-      properties:
-        internal:
-          description: Comment as added by merchant
-          type: string
-    OrderDebtor:
-      description: Order debitor details
-      properties:
-        id:
-          description: "ID of the corresponding customer, if any"
-          type: string
-          format: uuid
-        gender:
-          deprecated: true
-          description: "Gender description (deprecated: use [Invoice]Address.gender)"
-          type: string
-        name:
-          deprecated: true
-          description: "Full name (deprecated: use [Invoice]Address.name)"
-          type: string
-        company:
-          deprecated: true
-          description: "Company name (deprecated: use [Invoice]Address.company)"
-          type: string
-        email:
-          description: Email address
-          type: string
-        phone:
-          deprecated: true
-          description: "Phone number (deprecated: use [Invoice]Address.phone)"
-          type: string
-        bankaccount:
-          deprecated: true
-          description: "Bankaccount number (deprecated: use InvoiceAddress.bankaccount)"
-          type: string
-        link_to_account:
-          description: Link to debitor account
-          type: boolean
-        address:
-          $ref: "#/components/schemas/OrderAddress"
-    OrderDetail:
-      allOf:
-        - $ref: "#/components/schemas/BaseOrderDetail"
-        - properties:
-            articles:
-              description: Required for the 'article' type
-              type: array
-              items:
-                $ref: "#/components/schemas/OrderArticle"
-            weight:
-              description: Total weight for all items in this orderline
-              type: string
-            description:
-              description: Article description (including options)
-              type: string
-            price:
-              oneOf:
-                - type: array
-                  items:
-                    $ref: "#/components/schemas/TaxPrice"
-                - $ref: "#/components/schemas/TaxPrice"
-    BaseOrderDetail:
-      required:
-        - type
-        - quantity
-      properties:
-        id:
-          description: Unique identifier
-          type: string
-          format: uuid
-        type:
-          description: |-
-            OrderDetail type, one of:
-            - article
-            - custom
-          type: string
-        quantity:
-          description: Amount of items
-          type: integer
-        unit_price:
-          $ref: "#/components/schemas/TaxPrice"
-        unit_weight:
-          description: Custom item weight per unit; required for custom articles
-          type: string
-        price_override:
-          $ref: "#/components/schemas/Price"
-    OrderDetailPostable:
-      allOf:
-        - $ref: "#/components/schemas/BaseOrderDetail"
-        - properties:
-            articles:
-              description: Required for the 'article' type
-              type: array
-              items:
-                $ref: "#/components/schemas/OrderArticlePostable"
-    OrderPaymentPatchable:
-      description: Order payment
-      required:
-        - method
-      properties:
-        method:
-          $ref: "#/components/schemas/PaymentMethodListInput"
-        referrerUrl:
-          $ref: "#/components/schemas/PaymentReferrerUrl"
-        orderLines:
-          $ref: "#/components/schemas/OrderPaymentLinePortions"
-    OrderPaymentPostable:
-      description: Order payment
-      required:
-        - gateway
-        - method
-      properties:
-        gateway:
-          $ref: "#/components/schemas/PaymentGatewayListInput"
-        method:
-          $ref: "#/components/schemas/PaymentMethodListInput"
-        referrerUrl:
-          $ref: "#/components/schemas/PaymentReferrerUrl"
-        orderLines:
-          $ref: "#/components/schemas/OrderPaymentLinePortions"
-    OrderPaymentLinePortions:
-      description: Order lines to include in the payment (all lines by default)
-      example:
-        -
-          id: "5ddd8613-9254-4877-a752-fe97e8fcf26a"
-          quantity: 3
-        -
-          id: "71df5adb-81f4-4136-b11b-cef3815a5bff"
-        -
-          id: "ce51bbf9-f4dc-43f5-88d2-9a1b6948b97b"
-          quantity: 2
-          price: 599
-        -
-          id: "63506cb5-c53a-4fda-a81c-914b1a190293"
-          price: 1099
-      type: array
-      items:
-        properties:
-          id:
-            description: Unique identifier
-            type: string
-            format: uuid
-          quantity:
-            description: Override amount of items
-            type: integer
-          price:
-            description: Override price in minor currency units (eg cents)
-            type: integer
-    OrderPaymentSummary:
-      deprecated: true
-      description: Order payment details (available/required if Order.price.total <> 0.00)
-      properties:
-        gateway_name:
-          $ref: "#/components/schemas/PaymentGatewayList"
-        method_name:
-          $ref: "#/components/schemas/PaymentMethodList"
-        status:
-          $ref: "#/components/schemas/OrderPaymentStatus"
-    OrderPaymentStatus:
-      deprecated: true
-      description: Order payment status details
-      properties:
-        id:
-          description: |-
-            0: Status unknown
-            1: Successful
-            2: Cancelled
-            3: Failed
-            4: Expired
-            5: Pending
-            6: Refused
-            7: Refunded
-          type: integer
-        text:
-          description: Payment status description
-          type: string
-    OrderPrice:
-      properties:
-        tax:
-          description: Vat charge(s)
-          type: array
-          items:
-            $ref: "#/components/schemas/TaxPrice"
-        total:
-          description: Total order price
-          type: string
-    OrderShipping:
-      properties:
-        country:
-          $ref: "#/components/schemas/OrderShippingCountry"
-    OrderStatus:
-      description: Order status details
-      properties:
-        status:
-          description: Identifier for the order status
-          type: integer
-        description:
-          description: Description of the order status
-          type: string
-        credit_order:
-          description: True if the status is allowed for (and signifies) a credit order
-          type: boolean
-      example:
-        status: 1
-        description: Order Pending
-        credit_order: false
-    PaymentGateways:
-      description: List of payment gateways and methods
-      properties:
-        gateways:
-          type: array
-          items:
-            $ref: "#/components/schemas/PaymentGateway"
-      example:
-        gateways:
-          - name: mollie
-            displayName: Mollie
-            websiteUrl: https://www.mollie.com/
-            methods:
-              - name: ideal
-                displayName: iDEAL
-    PaymentGateway:
-      description: Payment Gateway
-      properties:
-        name:
-          description: Unique identifying name for the given gateway
-          type: string
-        displayName:
-          description: Gateway name for displaying
-          type: string
-        websiteUrl:
-          description: Link to the gateways website
-          type: string
-        methods:
-          description: List of available methods for the given gateway
-          type: array
-          items:
-            $ref: "#/components/schemas/PaymentMethod"
-    PaymentGatewayList:
-      deprecated: true
-      description: Payment gateway name
-      type: string
-      enum:
-        - "afterpay"
-        - "basic"
-        - "ingenico"
-        - "klarna_checkout"
-        - "mollie"
-        - "mollieOld"
-        - "multisafepay"
-        - "paynl"
-        - "paypal"
-        - "paytor"
-        - "sisow"
-        - "sumup"
-        - "zettle"
-    PaymentGatewayListInput:
-      description: Payment gateway name
-      type: string
-      enum:
-        - "basic"
-        - "klarna_checkout"
-        - "mollie"
-        - "multisafepay"
-        - "paynl"
-        - "paypal"
-        - "sisow"
-        - "sumup"
-        - "zettle"
-    PaymentMethodList:
-      deprecated: true
-      description: Payment method name
-      type: string
-      enum:
-        - "advance"
-        - "afterpay"
-        - "apple_pay"
-        - "bancontact"
-        - "bank_transfer"
-        - "belfius"
-        - "bitcoin"
-        - "card"
-        - "cash"
-        - "creditcard"
-        - "directdebit"
-        - "external"
-        - "giropay"
-        - "ideal"
-        - "ideal:issuer"
-        - "invoice"
-        - "in_arrears"
-        - "kbccbc"
-        - "klarna_checkout"
-        - "klarna_paylater"
-        - "klarna_paynow"
-        - "klarna_sliceit"
-        - "maestro"
-        - "mastercard"
-        - "paypal"
-        - "paysafecard"
-        - "pickup"
-        - "podium_giftcard"
-        - "rembours"
-        - "singledebit"
-        - "sofortbanking"
-        - "visa"
-        - "webshop_giftcard"
-    PaymentMethodListInput:
-      description: Payment method name
-      type: string
-      enum:
-        - "advance"
-        - "afterpay"
-        - "apple_pay"
-        - "bancontact"
-        - "belfius"
-        - "card"
-        - "cash"
-        - "creditcard"
-        - "directdebit"
-        - "external"
-        - "giropay"
-        - "ideal"
-        - "ideal:issuer"
-        - "invoice"
-        - "kbccbc"
-        - "klarna_checkout"
-        - "klarna_paylater"
-        - "klarna_paynow"
-        - "klarna_sliceit"
-        - "maestro"
-        - "mastercard"
-        - "paypal"
-        - "paysafecard"
-        - "pickup"
-        - "rembours"
-        - "singledebit"
-        - "sofortbanking"
-        - "visa"
-        - "webshop_giftcard"
-    PaymentMethod:
-      description: Payment method
-      properties:
-        name:
-          description: Unique identifying name for the given method
-          type: string
-        displayName:
-          description: Localized name of the payment method
-          type: string
-    StorePaymentGateways:
-      description: List of payment gateways and methods
-      properties:
-        gateways:
-          type: array
-          items:
-            $ref: "#/components/schemas/StorePaymentGateway"
-      example:
-        gateways:
-          - name: mollie
-            displayName: Mollie
-            websiteUrl: https://www.mollie.com/
-            methods:
-              - name: ideal
-                displayName: iDEAL
-                settings:
-                  cost:
-                    amount: "0.05"
-                    percentage: "5.87"
-    StorePaymentGateway:
-      description: Payment Gateway
-      properties:
-        name:
-          description: Unique identifying name for the given gateway
-          type: string
-        displayName:
-          description: Gateway name for displaying
-          type: string
-        websiteUrl:
-          description: Link to the gateways website
-          type: string
-        methods:
-          description: List of available methods for the given gateway
-          type: array
-          items:
-            $ref: "#/components/schemas/StorePaymentMethod"
-    StorePaymentMethod:
-      description: Payment method
-      properties:
-        name:
-          description: Unique identifying name for the given method
-          type: string
-        displayName:
-          description: Localized name of the payment method
-          type: string
-        settings:
-          description: List of settings for the given method, specific for the
-            given store
-          type: object
-          properties:
-            cost:
-              description: Charge per transaction for the given method, can be
-                a combination of fixed and percentual
-              type: object
-              properties:
-                amount:
-                  description: Fixed charge per transaction
-                  type: string
-                percentage:
-                  description: Percentual charge per transaction
-                  type: string
-    OrderShippingCountry:
-      description: Order shipping country settings
-      properties:
-        description:
-          description: Country description
-          type: string
-        isocode:
-          description: Country iso code
-          type: string
-    TaxPolicyRegion:
-      description: Tax policy region
-      example:
-        regionCode: NL
-        taxEnabled: true
-        taxNumber: NL000099998B57
-        taxRate: 0.21
-        shippingTaxMethod: "fixed"
-        shippingTaxRate: 0.21
-        transactionTaxMethod: "proportional"
-        transactionTaxRate: null
-        overrides:
-          - taxRate: 0.06
-            items:
-              - type: product
-                references: [product-1, product-3]
-      properties:
-        regionCode:
-          description: Country code (ISO 3166-1 alpha-2)
-          type: string
-          pattern: '^[A-Z]{2}$'
-        taxEnabled:
-          description: Whether tax is enabled
-          type: boolean
-        taxNumber:
-          description: The tax number/ID, currently only supports EU VAT number
-          type: string
-          format: vat-number
-          nullable: true
-        taxRate:
-          description: The general tax rate
-          type: string
-          format: float
-          minimum: 0
-          maximum: 1
-          nullable: true
-        shippingTaxMethod:
-          description: What method is being used to calculate shipping tax
-          type: string
-          enum:
-            - 'fixed'
-            - 'proportional'
-        shippingTaxRate:
-          description: Shipping tax rate
-          type: string
-          format: float
-          minimum: 0
-          maximum: 1
-          nullable: true
-        transactionTaxMethod:
-          description: What method is being used to calculate transaction tax
-          type: string
-          enum:
-            - 'fixed'
-            - 'proportional'
-        transactionTaxRate:
-          description: Transaction tax rate
-          type: string
-          format: float
-          minimum: 0
-          maximum: 1
-          nullable: true
-        overrides:
-          description: Tax overrides
-          type: array
-          items:
-            $ref: '#/components/schemas/TaxPolicyRegionOverride'
-    TaxPolicyRegionOverride:
-      description: Tax policy region override
-      properties:
-        taxRate:
-          description: Tax rate for override
-          type: string
-          format: float
-          minimum: 0
-          maximum: 1
-        items:
-          description: Override items
-          type: array
-          items:
-            $ref: '#/components/schemas/TaxPolicyOverride'
-      required:
-        - taxRate
-        - items
-    TaxPolicyOverride:
-      description: Tax policy override
-      properties:
-        type:
-          description: What kind of override
-          type: string
-          enum:
-            - 'product'
-            - 'collection'
-        references:
-          description: List of references this override applies to
-          type: array
-          items:
-            description: Identifier of overridden item
-            type: string
-      required:
-        - type
-        - references
-    TaxPrice:
-      required:
-        - rate
-      properties:
-        rate:
-          description: Vat percentage
-          type: string
-        amount:
-          description: Amount (excluding tax), may have up to 6 decimals
-          type: string
-        amount_including_tax:
-          description: Amount (including tax) with exactly 2 decimals.
-            May be used for POST operation with custom items,
-            where either amount or amount_including_tax must be specified
-          type: string
-    Price:
-      description: Price (in decimal notation)
-      type: string
-    Error:
-      description: Error response
-      properties:
-        code:
-          description: Unique error code
-          type: integer
-        message:
-          description: Short error message
-          type: string
-        description:
-          description: Extended error information
-          type: string
-    Discountcode:
-      allOf:
-        - properties:
-            id:
-              description: Discountcode identifier
-              type: string
-              format: uuid
-            customer_id:
-              description: Identifier of the customer the discountcode is valid for
-              nullable: true
-              type: string
-              format: uuid
-        - $ref: '#/components/schemas/DiscountcodePostable'
-      example:
-        id: 'ac941823-9b4a-492a-9157-4c7124419fa1'
-        code: 'christmas-sale-1337'
-        customer_id: 'f7ec4a49-3e8a-436d-9b32-5f3cf6a8ac3a'
-        description: 'Christmas 2017'
-        percentage_discount: '10.00'
-        fixed_discount: '2.50'
-        minimum_order_price: '100.00'
-        minimum_products: 3
-        applies_to_shipping: false
-        free_shipping: false
-        applies_to_action_prices: false
-        single_use: false
-        active: true
-        valid_from: '2017-12-01'
-        valid_until: '2017-12-26'
-        valid_products:
-          -
-            product_id: '7494373'
-          -
-            product_id: '3760904'
-            max_quantity: 3
-    DiscountcodePatchable:
-      $ref: '#/components/schemas/DiscountcodePostable'
-    DiscountcodePostable:
-      properties:
-        code:
-          description: Unique identifying code for the discountcode
-          type: string
-          maxLength: 20
-        description:
-          description: Description of the discountcode (internal)
-          type: string
-        percentage_discount:
-          description: Percentual discount which is applied
-          type: string
-        fixed_discount:
-          description: Fixed amount of discount which is applied
-          type: string
-        minimum_order_price:
-          description: Minimum total price of valid articles in the order for the
-            discountcode to be valid
-          type: string
-        minimum_products:
-          description: Minimum number of products in the order for the discountcode to be
-            valid
-          type: integer
-        applies_to_shipping:
-          description: Fixed discount may also apply to shipping costs
-          type: boolean
-        free_shipping:
-          description: All shipping costs are discounted
-          type: boolean
-        applies_to_action_prices:
-          description: Discountcode is valid for articles with an action price
-          type: boolean
-        single_use:
-          description: Discountcode can be used only once
-          type: boolean
-        active:
-          description: Discountcode is active
-          type: boolean
-        valid_from:
-          description: Date the discountcode is valid from
-          type: string
-          format: date
-        valid_until:
-          description: Date the discountcode is valid until
-          type: string
-          format: date
-        valid_article_ids:
-          deprecated: true
-          description: 'Specific article identifiers the discountcode is valid for (deprecated: use valid_products)'
-          type: array
-          items:
-            type: string
-        valid_product_ids:
-          description: Specific products the discountcode is valid for
-          type: array
-          items:
-            properties:
-              product_id:
-                description: Identifier of the product the discountcode is valid for
+    parameters:
+        customer_id_path:
+            name: customerId
+            in: path
+            description: Customer Identifier
+            required: true
+            schema:
                 type: string
-              max_quantity:
-                description: Maximum number of times the discountcode is valid for this product
+                format: uuid
+        customer_address_id_path:
+            name: addressId
+            in: path
+            description: Address Identifier
+            required: true
+            schema:
+                type: string
+                format: uuid
+        order_number_path:
+            name: order_number
+            in: path
+            description: Order number
+            required: true
+            schema:
                 type: integer
-        invalid_article_ids:
-          deprecated: true
-          description: 'Specific article identifiers the discountcode is not valid for (deprecated: use invalid_product_ids)'
-          type: array
-          items:
-            type: string
-        invalid_product_ids:
-          description: Specific product identifiers the discountcode is not valid for
-          type: array
-          items:
-            type: string
-        valid_category_ids:
-          description: Specific category identifiers the discountcode is valid for
-          type: array
-          items:
-            type: string
-        invalid_category_ids:
-          description: Specific category identifiers the discountcode is not valid for
-          type: array
-          items:
-            type: string
-      example:
-        description: 'Christmas 2017'
-        percentage_discount: '10.00'
-        fixed_discount: '2.50'
-        minimum_order_price: '100.00'
-        minimum_products: 3
-        applies_to_shipping: false
-        free_shipping: false
-        applies_to_action_prices: false
-        single_use: false
-        active: true
-        valid_from: '2017-12-01'
-        valid_until: '2017-12-26'
-        valid_products:
-          -
-            product_id: '7494373'
-          -
-            product_id: '3760904'
-            max_quantity: 3
-    NewsletterSubscriber:
-      example:
-        email: alberto@studio100.be
-        name: Alberto Vermicelli
-        activated: false
-        created_date: "2016-07-04"
-        created_time: "13:37:00"
-        updated_date: "2016-07-25"
-        updated_time: "13:37:00"
-      allOf:
-        - $ref: "#/components/schemas/NewsletterSubscriberPatchable"
-        - properties:
-            email:
-              description: Subscriber email-address
-              type: string
-            activated:
-              description: Subscriber has been activated (confirmed)
-              type: boolean
-            created_date:
-              description: Subscriber creation date
-              type: string
-              format: date
-            created_time:
-              description: Subscriber creation time. Will be merged in `created_date` in
-                future version
-              type: string
-              format: time
-            updated_date:
-              description: Subscriber last updated date
-              type: string
-              format: date
-            updated_time:
-              description: Subscriber last updated time. Will be merged in `updated_date`
-                in future version
-              type: string
-              format: time
-    NewsletterSubscriberPostable:
-      example:
-        name: Alberto Vermicelli
-        email: alberto@studio100.be
-      allOf:
-        - $ref: "#/components/schemas/NewsletterSubscriberPatchable"
-        - properties:
-            email:
-              description: Subscriber email-address
-              type: string
-    NewsletterSubscriberPatchable:
-      properties:
-        name:
-          description: Subscriber name
-          type: string
-      example:
-        name: Alberto Vermicelli
-    OfflineLocation:
-      example:
-        id: 7127e08a-4af0-4fdf-ac7b-157be3345df0
-        name: "Store location Oss: Register 2"
-        street: Molenstraat
-        street_number: "62"
-        zipcode: 5341GE
-        city: Oss
-        country: Netherlands
-        country_code: NL
-        phone: 06-12345678
-        email: support@mijnwebwinkel.nl
-        note: Open from 09:00 till 17:00
-        deleted: false
-      allOf:
-        - $ref: "#/components/schemas/OfflineLocationPatchable"
-        - properties:
-            id:
-              description: Offline location identifier (UUID string)
-              type: string
-            country:
-              description: Country name
-              type: string
-    OfflineLocationPatchable:
-      properties:
-        name:
-          description: Point of sale name
-          type: string
-          maxLength: 80
-        street:
-          description: Point of sale address (street)
-          type: string
-          maxLength: 255
-        street_number:
-          description: Point of sale address (street number)
-          type: string
-          maxLength: 20
-        zipcode:
-          description: Point of sale zipcode
-          type: string
-          maxLength: 10
-        city:
-          description: Point of sale city
-          type: string
-          maxLength: 100
-        country_code:
-          description: ISO 3166-1 alpha-2 code
-          type: string
-        phone:
-          description: Point of sale phonenumber (E164 format)
-          type: string
-          maxLength: 15
-        email:
-          description: Point of sale emailaddress
-          type: string
-          maxLength: 255
-        note:
-          description: Additional notes for merchant
-          type: string
-          maxLength: 255
-        deleted:
-          description: Point of sale location is inactive (soft deleted)
-          type: boolean
-      example:
-        name: "Store location Oss: Register 2"
-        street: Molenstraat
-        street_number: "62"
-        zipcode: 5341GE
-        city: Oss
-        country_code: NL
-        phone: 06-12345678
-        email: support@mijnwebwinkel.nl
-        note: Open from 09:00 till 17:00
-        deleted: false
-    Payment:
-      example:
-        id: 8c1ed7ea-c19a-4137-8517-7d3f580b3b97
-        gateway: mollie
-        method: ideal:ideal_INGBNL2A
-        gatewayReference: ord_8yalb
-        price: 5339
-        currency: EUR
-        storeId: 494c24a3-2243-484a-a81e-b3098d4dc870
-        reference: 33eea580-2381-44bf-b355-d99a13d4f770
-        isTest: false
-        createdAt: 2021-06-29T14:41:26+02:00
-        updatedAt: 2021-06-29T14:41:26+02:00
-        mutations: [
-          {
-            id: 196,
-            type: authorize,
-            reference: null,
-            price: 5339,
-            description: null,
-            createdAt: 2022-01-18T12:35:27+01:00,
-            expiresAt: null
-          },
-          {
-            id: 198,
-            type: capture,
-            reference: null,
-            price: 5339,
-            description: null,
-            createdAt: 2022-01-18T12:35:27+01:00,
-            expiresAt: null
-          }
-        ]
-        order:
-          id: c5ef58b5-3cd7-4fcc-9d73-9c4c8b39dc31
-          reference: 2342
-          price: 5339
-          tax: 927
-          locale: nl_NL
-          deliveryType: delivery
-          lines: [
-            {
-              id: 7a6a2405-d8fe-40e0-809f-6b3a8a48e3de,
-              type: physical,
-              name: Fusce eget turpis,
-              description: Aliquam sed eros non massa malesuada condimentum in sit amet eros.,
-              quantity: 1,
-              price: 4839,
-              tax: 840,
-              taxRate: "0.2100"
-            },
-            {
-              id: f5acaf51-33ab-47b8-b853-6560ee4b8ec9,
-              type: shipping_fee,
-              name: Shipping costs,
-              description: Shipping costs,
-              quantity: 1,
-              price: 500,
-              tax: 87,
-              taxRate: "0.2107"
-            }
-          ]
-          customer:
-            id: ded42190-7f99-4439-b94d-e04c12efcaff
-            email: foo@example.org
-            birthDate: null
-            iban: null
-            ip: 192.168.16.1
-            billingAddress:
-              id: 932c7e56-9de8-4cde-bc79-5d3e78bc6897
-              name:
-                first: John
-                last: Doe
-              company: MyOnlineStore B.V.
-              street:
-                name: Molenstraat
-                number: 56
-                suffix: null
-              zipCode: 5341 GE
-              city: Oss
-              country: NL
-              phone: "+31412668011"
-              gender: null
-            shippingAddress:
-              id: ded42190-7f99-4439-b94d-e04c12efcaff
-              email: foo@example.org
-              birthDate: null
-              iban: null
-              ip: 192.168.16.1
-              billingAddress:
-                id: f1bc2de0-cb7b-4e25-a278-db8a00c157ae
-                name:
-                  first: John
-                  last: Doe
-                company: MyOnlineStore B.V.
-                street:
-                  name: Molenstraat
-                  number: 56
-                  suffix: null
-                zipCode: 5341 GE
-                city: Oss
-                country: NL
-                phone: "+31412668011"
-                gender: null
-        properties:
-          minimum_age: 18
-          shipping_region: NL
-          validation_callback_url: https://www.example.org/checkout/api/v1/orders/adbac24c-0f4b-4dbf-8aac-beecbfc3ee30/validate
-      properties:
-        id:
-          description: Unique identifier
-          type: string
-          format: uuid
-        gateway:
-          $ref: "#/components/schemas/PaymentGatewayList"
-        method:
-          description: Payment method
-          type: string
-        gatewayReference:
-          description: Gateway reference
-          type: string
-        price:
-          description: Price in minor units
-          type: integer
-        currency:
-          description: Currency (ISO 4217 code)
-          type: string
-        storeId:
-          description: Store unique identifier
-          type: string
-          format: uuid
-        reference:
-          description: Unique reference
-          type: string
-          format: uuid
-        referrerUrl:
-          $ref: "#/components/schemas/PaymentReferrerUrl"
-        isTest:
-          description: Is a test payment
-          type: boolean
-        createdAt:
-          description: Payment creation date
-          type: string
-          format: date-time
-        updatedAt:
-          description: Payment last updated date
-          type: string
-          format: date-time
-          nullable: true
-        mutations:
-          description: Payment mutations
-          type: array
-          items:
-            $ref: '#/components/schemas/PaymentMutation'
-        order:
-          description: Payment order details
-          type: object
-          properties:
-            id:
-              description: Unique identifier
-              type: string
-              format: uuid
-            reference:
-              description: The order number
-              type: string
-            price:
-              description: Price in minor units
-              type: integer
-            tax:
-              description: Tax price in minor units
-              type: integer
-            locale:
-              description: Language of the order contents (ISO 3166-1 alpha-2 code)
-              type: string
-            deliveryType:
-              description: Delivery type
-              type: string
-              enum:
-                - "pickup"
-                - "delivery"
-            lines:
-              type: array
-              items:
+        payment_id_path:
+            name: paymentId
+            in: path
+            description: Payment Identifier
+            required: true
+            schema:
+                type: string
+                format: uuid
+        payment_embed:
+            name: embed
+            in: query
+            description: Either one or multiple (comma-separated) of "properties", "mutations", or "order"
+            required: false
+            schema:
+                type: string
+            examples:
+                order:
+                    description: Include the order details of the payment
+                    value: order
+                mutations:
+                    description: Include the mutations of the payment
+                    value: mutations
                 properties:
-                  id:
+                    description: Include the properties of the payment
+                    value: properties
+        limit:
+            name: limit
+            in: query
+            description: "Maximum number of items to return (max: 100)"
+            required: false
+            schema:
+                type: integer
+                maximum: 100
+                default: 10
+        offset:
+            name: offset
+            in: query
+            description: Number of items to skip
+            required: false
+            schema:
+                type: integer
+        start_date:
+            name: start_date
+            in: query
+            description: Minimum date value
+            required: false
+            schema:
+                type: string
+                format: date
+        end_date:
+            name: end_date
+            in: query
+            description: Maximum date value
+            required: false
+            schema:
+                type: string
+                format: date
+        version:
+            name: version
+            in: path
+            required: true
+            schema:
+                type: string
+                enum:
+                    - "1"
+                    - "2-beta"
+                default: "1"
+        region_code_path:
+            name: code
+            in: path
+            description: Region code (ISO 3166-1 alpha-2)
+            required: true
+            schema:
+                type: string
+                pattern: '^[A-Z]{2}$'
+        language:
+            name: language
+            in: query
+            description: Shop language to return content for
+            required: false
+            schema:
+                type: string
+                enum:
+                    - nl_NL
+                    - en_GB
+                    - de_DE
+                    - fr_FR
+                    - es_ES
+                    - en_US
+                    - pt_PT
+                    - it_IT
+                    - da_DK
+                    - sv_SE
+                    - no_NO
+                    - tr_TR
+                    - pl_PL
+                default: nl_NL
+        format:
+            name: format
+            in: query
+            description: Response format
+            required: false
+            schema:
+                type: string
+                enum:
+                    - json
+                    - xml
+                default: json
+        archived:
+            name: archived
+            in: query
+            description: Archived status
+            required: false
+            schema:
+                type: boolean
+        status_id:
+            name: status_id
+            in: query
+            description: Only include orders with specific status
+            required: false
+            schema:
+                type: integer
+        status_changed_start_date:
+            name: status_changed_start_date
+            in: query
+            description: "Minimum for status changed datetime (format: yyyy-mm-dd hh:mm:ss)"
+            required: false
+            schema:
+                type: string
+                format: date-time
+        status_changed_end_date:
+            name: status_changed_end_date
+            in: query
+            description: "Maximum for status changed datetime (format: yyyy-mm-dd hh:mm:ss)"
+            required: false
+            schema:
+                type: string
+                format: date-time
+        debtor_email:
+            name: debtor_email
+            in: query
+            description: |
+                Filter results on the e-mail address of the debtor. Uses an `OR` condition when
+                combined with `debtor_id`.
+            required: false
+            schema:
+                type: string
+        debtor_id:
+            name: debtor_id
+            in: query
+            description: |
+                Filter results on the ID of the debtor. Uses an `OR` condition when
+                combined with `debtor_email`.
+            required: false
+            schema:
+                type: string
+                format: uuid
+        store:
+            name: store
+            in: path
+            description: The store's UUID or `me` alias to retrieve the store from the access token
+            required: true
+            schema:
+                type: string
+        created_start_date:
+            name: created_start_date
+            in: query
+            description: "Minimum for created datetime (format: yyyy-mm-dd hh:mm:ss)"
+            required: false
+            schema:
+                type: string
+                format: date-time
+        created_end_date:
+            name: created_end_date
+            in: query
+            description: "Maximum for created datetime (format: yyyy-mm-dd hh:mm:ss)"
+            required: false
+            schema:
+                type: string
+                format: date-time
+        changed_start_date:
+            name: changed_start_date
+            in: query
+            description: "Minimum for changed datetime (format: yyyy-mm-dd hh:mm:ss)"
+            required: false
+            schema:
+                type: string
+                format: date-time
+        changed_end_date:
+            name: changed_end_date
+            in: query
+            description: "Maximum for changed datetime (format: yyyy-mm-dd hh:mm:ss)"
+            required: false
+            schema:
+                type: string
+                format: date-time
+        use_url_id:
+            name: use_url_id
+            in: query
+            description: Enable this when article_id equals the ID from article page URLs
+            required: true
+            schema:
+                type: boolean
+                default: false
+        activated:
+            name: activated
+            in: query
+            description: Filter on activated (confirmed) subscriptions
+            required: false
+            schema:
+                type: boolean
+        activate:
+            name: activate
+            in: query
+            description: Activation email should be send to subscriber (if not already activated)
+            required: false
+            schema:
+                type: boolean
+                default: false
+        ids:
+            name: ids
+            in: query
+            description: Only include products with specific ids
+            required: false
+            schema:
+                type: array
+                items:
+                    type: integer
+        uuids:
+            name: uuids
+            in: query
+            description: Only include products with specific UUID's
+            required: false
+            schema:
+                type: array
+                items:
+                    type: string
+                    format: uuid
+        test:
+            name: test
+            in: query
+            description: Include test orders in the response
+            required: false
+            schema:
+                type: boolean
+                default: false
+    requestBodies:
+        postArticleListsLists:
+            content:
+                application/json:
+                    schema:
+                        type: array
+                        items:
+                            type: integer
+            description: List Ids
+            required: true
+    securitySchemes:
+        StoreToken:
+            description: The merchant may create a token to give your application access to their data.
+                This can be done from the shop backend through **Settings --> API --> Add new token**. This token should be kept secret.
+            type: apiKey
+            in: query
+            name: token
+        PartnerToken:
+            description: This token can be obtained by [registering](https://www.mijnwebwinkel.nl/contact) your (intended) application.
+                This token should be kept secret.
+            type: apiKey
+            in: query
+            name: partner_token
+    schemas:
+        Address:
+            description: Generic address
+            required:
+                - name
+                - zipcode
+            properties:
+                id:
+                    description: Address UUID. No other address field is required if an ID is
+                        provided.
+                    type: string
+                gender:
+                    description: Gender description
+                    type: string
+                name:
+                    description: Full name
+                    type: string
+                company:
+                    description: Company name
+                    type: string
+                phone:
+                    description: Phone number
+                    type: string
+                street:
+                    description: Street name
+                    type: string
+                number:
+                    description: Housenumber
+                    type: string
+                zipcode:
+                    type: string
+                city:
+                    type: string
+                country:
+                    deprecated: true
+                    description: (Localized) country name
+                    type: string
+                country_code:
+                    description: ISO 3166-1 alpha-2 country code
+                    type: string
+        Article:
+            required:
+                - name
+                - categories
+            example:
+                id: 123
+                uuid: "095be615-a8ad-4c33-8e9c-c7612fbf6c9f"
+                name: Funny cushion
+                description: Endless fun
+                sku: ART758379-L
+                badge_text: van - voor
+                taxable: true
+                price:
+                    default: 12.5
+                    action: 9.95
+                    purchase: 8.95
+                created_date: "2016-07-04"
+                created_time: "09:11:25"
+                updated_date: "2016-07-25"
+                updated_time: "11:16:59"
+                stock: 15
+                delivery_days: 5
+                meta_title: "Funny shop: Funny Cushion"
+                meta_description: Awesome description here
+                can_backorder: false
+                extra:
+                    invisible:
+                        weight: "0.25"
+                        barcode: "8712345678906"
+                    visible:
+                        Fart power (Beaufort): "5"
+                url: https://myonline.store/a-245/the-best-balloon-animals-for-your-party/funny-cushion
+                categories:
+                    -   category_id: 748020
+                        article_url_id: 245
+                        is_active: true
+                        is_main: true
+                lists:
+                    -   id: 193177
+                        name: Sounds
+                        description: Special laugh sounds
+                        has_images: true
+                        options:
+                            -   id: 71362
+                                name: Jim Carrey
+                                price: "99.00"
+                                image_ids:
+                                    - 7e2009bf-f4a6-4f6d-9874-14ed1341229b
+                            -   id: 71363
+                                name: Clown
+                                price: "5.00"
+                variants:
+                    -   id: 1362
+                        options:
+                            "193177": Jim Carrey
+                        stock: 3
+                images:
+                    -   position: 2
+                        id: 7e2009bf-f4a6-4f6d-9874-14ed1341229b
+                        original_name: "my_uploaded_image"
+                        urls:
+                            full: https://asset.myonlinestore.com/winkel/winkelnaam/images/full/b1787d2f15742a7d9c869f186b948ddbc2faecb87
+                            article: https://asset.myonlinestore.com/winkel/winkelnaam/images/article/b1787d2f15742a7d9c869f186b948ddbc2faecb87
+                            thumb: https://asset.myonlinestore.com/winkel/winkelnaam/images/thumb/b1787d2f15742a7d9c869f186b948ddbc2faecb87
+            allOf:
+                -   $ref: "#/components/schemas/BaseArticle"
+                -   properties:
+                        id:
+                            description: "Internal article ID (deprecated: use `uuid` instead)"
+                            type: integer
+                            deprecated: true
+                        uuid:
+                            description: Article UUID
+                        created_date:
+                            description: Creation date
+                            type: string
+                            format: date
+                        created_time:
+                            description: Creation time
+                            type: string
+                            format: time
+                        updated_date:
+                            description: Last updated date
+                            type: string
+                            format: date
+                        updated_time:
+                            description: Last updated time
+                            type: string
+                            format: time
+                        can_backorder:
+                            description: Available for purchase if sold out (see also delivery_days)
+                            type: boolean
+                        categories:
+                            description: Pages the article is shown on
+                            type: array
+                            items:
+                                $ref: "#/components/schemas/CategoryArticle"
+                        lists:
+                            description: Choices offered for the article
+                            type: array
+                            items:
+                                $ref: "#/components/schemas/ConfiguratorArticleList"
+                        images:
+                            type: array
+                            items:
+                                $ref: "#/components/schemas/ArticleImage"
+                        variants:
+                            description: Versions of the article which have at least one diverging field value
+                            type: array
+                            items:
+                                $ref: "#/components/schemas/ArticleVariant"
+        ArticlePatchable:
+            example:
+                name: Funny cushion
+                description: Endless fun
+                sku: ART758379-L
+                badge_text: van - voor
+                taxable: true
+                price:
+                    default: 12.5
+                    action: 9.95
+                    purchase: 8.95
+                stock: 15
+                delivery_days: 5
+                meta_title: "Funny shop: Funny Cushion"
+                meta_description: Awesome description here
+                can_backorder: false
+                extra:
+                    invisible:
+                        weight: "0.25"
+                        barcode: "8712345678906"
+                    visible:
+                        Fart power (Beaufort): "5"
+                categories:
+                    -   category_id: 748020
+                        is_main: true
+                        is_active: true
+                    -   category_id: 824312
+                        article_url_id: 4005
+                        is_main: false
+                        is_active: true
+                lists:
+                    -   id: 293822
+                        has_images: true
+                        options:
+                            -   id: 1690460
+                                image_ids:
+                                    - 8fc37dbc-3704-4807-bb75-3e1917b5326d
+                            -   id: 1991624
+                                image_ids:
+                                    - 8fc37dbc-3704-4807-bb75-3e1917b5326d
+                                    - 7e2009bf-f4a6-4f6d-9874-14ed1341229b
+                variants:
+                    -   id: 1362
+                        stock: 27
+                images:
+                    -   id: 7e2009bf-f4a6-4f6d-9874-14ed1341229b
+                        url: https://myonlineimage.com/my-image-1.jpg
+                        position: 1
+                    -   id: 8fc37dbc-3704-4807-bb75-3e1917b5326d
+                        url: https://myonlineimage.com/my-image-2.jpg
+                        position: 2
+            allOf:
+                -   $ref: "#/components/schemas/ArticlePostable"
+                -   properties:
+                        categories:
+                            type: array
+                            items:
+                                $ref: "#/components/schemas/CategoryArticlePatchable"
+                        variants:
+                            type: array
+                            items:
+                                $ref: "#/components/schemas/ArticleVariant"
+        ArticlePostable:
+            example:
+                name: Funny cushion
+                description: Endless fun
+                sku: ART758379-L
+                badge_text: van - voor
+                taxable: true
+                price:
+                    default: 12.5
+                    action: 9.95
+                    purchase: 8.95
+                stock: 15
+                delivery_days: 5
+                meta_title: "Funny shop: Funny Cushion"
+                meta_description: Awesome description here
+                can_backorder: false
+                extra:
+                    invisible:
+                        weight: "0.25"
+                        barcode: "8712345678906"
+                    visible:
+                        Fart power (Beaufort): "5"
+                categories:
+                    -   category_id: 748020
+                        is_main: true
+                        is_active: true
+                lists:
+                    -   id: 293822
+                        has_images: true
+                        options:
+                            -   id: 1690460
+                                image_ids:
+                                    - 8fc37dbc-3704-4807-bb75-3e1917b5326d
+                            -   id: 1991624
+                                image_ids:
+                                    - 8fc37dbc-3704-4807-bb75-3e1917b5326d
+                                    - 7e2009bf-f4a6-4f6d-9874-14ed1341229b
+                images:
+                    -   id: 7e2009bf-f4a6-4f6d-9874-14ed1341229b
+                        url: https://myonlineimage.com/my-image-1.jpg
+                        position: 1
+                    -   id: 8fc37dbc-3704-4807-bb75-3e1917b5326d
+                        url: https://myonlineimage.com/my-image-2.jpg
+                        position: 2
+            allOf:
+                -   $ref: "#/components/schemas/BaseArticle"
+                -   properties:
+                        categories:
+                            type: array
+                            items:
+                                $ref: "#/components/schemas/CategoryArticlePostable"
+                        lists:
+                            type: array
+                            items:
+                                $ref: "#/components/schemas/ConfiguratorArticleListPostable"
+                        images:
+                            type: array
+                            items:
+                                $ref: "#/components/schemas/ArticleImagePostable"
+        ArticleUploadImagePostable:
+            properties:
+                filename:
+                    type: string
+                position:
+                    type: integer
+                content:
+                    type: string
+                    format: base64
+        BaseArticle:
+            properties:
+                name:
+                    description: Name of the article
+                    type: string
+                description:
+                    description: Description for this article
+                    type: string
+                sku:
+                    description: Stock keeping unit
+                    type: string
+                badge_text:
+                    description: Additional text shown as badge
+                    type: string
+                taxable:
+                    description: Whether tax is charged when the article is sold
+                    type: boolean
+                price:
+                    $ref: "#/components/schemas/ArticlePrice"
+                stock:
+                    description: Number in stock (specify null for unlimited stock)
+                    type: integer
+                delivery_days:
+                    description: Delivery time (in days) if the article is sold out (see also can_backorder)
+                    type: integer
+                meta_title:
+                    description: Metadata title
+                    type: string
+                meta_description:
+                    description: Metadata description
+                    type: string
+                extra:
+                    $ref: "#/components/schemas/ArticleExtraFieldSet"
+        ArticleLimited:
+            properties:
+                id:
+                    description: Internal article id
+                    type: integer
+                name:
+                    description: Name of the article
+                    type: string
+                uuid:
+                    description: UUID of the article
+                    type: string
+                    format: uuid
+                is_main:
+                    description: Whether this is the primary category linked to the article
+                    type: boolean
+        ArticleExtraFieldSet:
+            properties:
+                visible:
+                  { }
+                invisible:
+                  { }
+        ArticleImage:
+            properties:
+                position:
+                    type: string
+                id:
+                    type: string
+                    format: uuid
+                original_name:
+                    description: Base name of the originally uploaded file
+                    type: string
+                url:
+                    deprecated: true
+                    type: string
+                urls:
+                    description: image url's for all formats
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/ArticleImageUrl"
+        ArticleImageUrl:
+            type: object
+            additionalProperties:
+                type: string
+        ArticleImagePostable:
+            properties:
+                id:
+                    type: string
+                    format: uuid
+                position:
+                    type: integer
+                url:
+                    type: string
+        ArticleList:
+            properties:
+                id:
+                    description: Internal article list id
+                    type: integer
+                name:
+                    type: string
+                description:
+                    type: string
+                options:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/ArticleListOption"
+            example:
+                name: Sounds
+                description: Special laugh sounds
+                options:
+                    -   name: Jim Carrey
+                        price: "99.00"
+                    -   name: Clown
+                        price: "5.00"
+        ArticleListOption:
+            properties:
+                id:
+                    type: integer
+                name:
+                    type: string
+                price:
+                    type: string
+        ConfiguratorArticleList:
+            example:
+                name: Sounds
+                description: Special laugh sounds
+                has_images: true
+                options:
+                    -   name: Jim Carrey
+                        price: "99.00"
+                        image_ids:
+                            - 1d29d35a-f8ef-404f-923a-cd08d8578909
+                    -   name: Clown
+                        price: "5.00"
+            properties:
+                has_images:
+                    type: boolean
+                    description: Whether the ConfiguratorArticleList has images enabled
+                options:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/ConfiguratorArticleListOption"
+            allOf:
+                -   $ref: "#/components/schemas/ArticleList"
+        ConfiguratorArticleListPostable:
+            required:
+                - id
+                - options
+            properties:
+                id:
+                    type: integer
+                    description: ArticleList id
+                has_images:
+                    type: boolean
+                    description: Whether the ConfiguratorArticleList has images enabled. This may be
+                        true for only 1 entry per article
+                options:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/ConfiguratorArticleListOptionPostable"
+        ConfiguratorArticleListOption:
+            properties:
+                image_ids:
+                    type: array
+                    items:
+                        type: string
+                        format: uuid
+                        description: ArticleImage
+            allOf:
+                -   $ref: "#/components/schemas/ArticleListOption"
+        ConfiguratorArticleListOptionPostable:
+            required:
+                - id
+                - image_ids
+            properties:
+                id:
+                    type: integer
+                    description: ArticleListOption id
+                image_ids:
+                    type: array
+                    items:
+                        type: string
+                        format: uuid
+                        description: ArticleImage
+        ArticlePrice:
+            properties:
+                default:
+                    description: The default price for which the product is offered (incl. tax depending on the value of [`store.prices_include_tax`](#tag/Store-information))
+                    type: string
+                action:
+                    description: The discounted price; overrides the default offer (incl. tax depending on the value of [`store.prices_include_tax`](#tag/Store-information))
+                    type: string
+                purchase:
+                    description: The purchase price (excl. tax)
+                    type: string
+        ArticleVariant:
+            properties:
+                id:
+                    description: Internal article variant id
+                    type: integer
+                options:
+                    description: Selected options
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/ArticleVariantOption"
+                stock:
+                    type: integer
+                can_backorder:
+                    type: boolean
+        ArticleVariantOption:
+            properties:
+                list_id:
+                    type: integer
+                option_id:
+                    type: integer
+                name:
+                    type: string
+        Category:
+            properties:
+                id:
+                    description: Category identifier
+                    type: integer
+                parent_category_id:
+                    description: ID of the parent category
+                    type: integer
+                hidden:
+                    description: Is the page hidden in the store
+                    type: boolean
+                title:
+                    description: Category page title
+                    type: string
+                content:
+                    description: Category page content
+                    type: string
+                meta_title:
+                    description: Metadata page title
+                    type: string
+                meta_description:
+                    description: Metadata page description
+                    type: string
+                article_order:
+                    description: |-
+                        Order in which products are shown on this page:
+                        1: price, ascending
+                        2: name, ascending
+                        3: last edited date, descending
+                        4: created date, descending
+                        5: manually defined, new products added at the bottom
+                        6: manually defined, new products added at the top
+                    type: integer
+                leafs:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/Category"
+                sorting:
+                    $ref: "#/components/schemas/CategorySorting"
+            example:
+                id: 78909
+                parent_category_id: 8569
+                hidden: false
+                title: The best balloon animals for your party
+                content: Balloon animals are great, don't you think?
+                meta_title: Balloon animals
+                meta_description: The best balloon animals for your party
+                article_order: 5
+                leafs:
+                    -   id: 78910
+                        parent_id: 78909
+                        hidden: true
+                        title: New collection
+                sorting:
+                    first: false
+                    last: false
+                    previous: 78908
+                    next: 78910
+        CategoryPostable:
+            required:
+                - title
+            example:
+                parent_category_id: 8569
+                hidden: false
+                title: The best balloon animals for your party
+                content: Balloon animals are great, don't you think?
+                meta_title: Balloon animals
+                meta_description: The best balloon animals for your party
+                article_order: 6
+                sorting:
+                    before: 78908
+            allOf:
+                -   $ref: "#/components/schemas/CategoryPatchable"
+        CategoryPatchable:
+            properties:
+                parent_category_id:
+                    description: ID of the parent category
+                    type: integer
+                hidden:
+                    description: Is the page hidden in the store
+                    type: boolean
+                title:
+                    description: Category page title
+                    type: string
+                content:
+                    description: Category page content
+                    type: string
+                meta_title:
+                    description: Metadata page title
+                    type: string
+                meta_description:
+                    description: Metadata page description
+                    type: string
+                article_order:
+                    description: |-
+                        Order in which products are shown on this page:
+                        1: price, ascending
+                        2: name, ascending
+                        3: last edited date, descending
+                        4: created date, descending
+                        5: manually defined
+                    type: integer
+                sorting:
+                    $ref: "#/components/schemas/CategorySortingPostable"
+            example:
+                parent_category_id: 8569
+                hidden: false
+                title: The best balloon animals for your party
+                content: Balloon animals are great, don't you think?
+                meta_title: Balloon animals
+                meta_description: The best balloon animals for your party
+                article_order: 5
+                sorting:
+                    before: 78908
+        CategoryArticle:
+            properties:
+                position:
+                    description: Relative position of the article on the page
+                    type: integer
+            allOf:
+                -   $ref: "#/components/schemas/CategoryArticlePatchable"
+        CategoryArticlePatchable:
+            properties:
+                article_url_id:
+                    description: Unique ID of the article linked to this page
+                    type: integer
+            allOf:
+                -   $ref: "#/components/schemas/CategoryArticlePostable"
+        CategoryArticlePostable:
+            required:
+                - category_id
+            properties:
+                category_id:
+                    description: Internal category id
+                    type: integer
+                is_active:
+                    description: Whether the article is visible in the store on this page
+                    type: boolean
+                is_main:
+                    description: Whether this is the primary category linked to the article
+                    type: boolean
+        CategorySorting:
+            description: Category sorting details
+            properties:
+                first:
+                    description: Is this category the first of it's branch?
+                    type: boolean
+                last:
+                    description: Is this category the last of it's branch?
+                    type: boolean
+                previous:
+                    description: ID of the previous category, if any
+                    type: integer
+                next:
+                    description: ID of the next category, if any
+                    type: integer
+        CategorySortingPostable:
+            description: Category sorting details
+            properties:
+                first:
+                    description: True if this category should be the first of it's branch
+                    type: boolean
+                last:
+                    description: True if this category should be the last of it's branch (default
+                        behavior)
+                    type: boolean
+                before:
+                    description: ID of the category this category should be placed after
+                    type: integer
+                after:
+                    description: ID of the category this category should be placed before
+                    type: integer
+        CountResponse:
+            description: Response of a count operation
+            properties:
+                count:
+                    description: The number of matching items
+                    type: integer
+        Customer:
+            description: Customer
+            properties:
+                id:
+                    description: Customer identifier
+                    type: string
+                    format: uuid
+                storeId:
+                    description: Store identifier that this customer belongs to
+                    type: string
+                    format: uuid
+                email:
+                    description: Email address
+                    type: string
+                    format: email
+                firstName:
+                    description: First name
+                    type: string
+                    nullable: true
+                lastName:
+                    description: Last name
+                    type: string
+                    nullable: true
+                dateOfBirth:
+                    description: Date of birth (yyyy-mm-dd)
+                    type: string
+                    nullable: true
+                    format: date
+                description:
+                    description: Information about the customer added by the merchant
+                    type: string
+                    nullable: true
+                addresses:
+                    description: Addresses for this customers
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CustomerAddress'
+        CustomerPatchable:
+            description: Customer Update Body
+            properties:
+                firstName:
+                    description: First name
+                    type: string
+                    nullable: true
+                lastName:
+                    description: Last name
+                    type: string
+                    nullable: true
+                dateOfBirth:
+                    description: Date of birth (yyyy-mm-dd)
+                    type: string
+                    nullable: true
+                    format: date
+                description:
+                    description: Information about the customer added by the merchant
+                    type: string
+                    nullable: true
+        CustomerAddress:
+            description: Customer Address
+            properties:
+                id:
+                    description: Address identifier
+                    type: string
+                    format: uuid
+                firstName:
+                    description: First name
+                    type: string
+                lastName:
+                    description: Last name
+                    type: string
+                street:
+                    description: Street name
+                    type: string
+                streetNumber:
+                    description: Street number (may include suffix)
+                    type: string
+                zipCode:
+                    description: Zip code
+                    type: string
+                city:
+                    description: City
+                    type: string
+                countryCode:
+                    description: ISO 3166-1 alpha-2 country code
+                    type: string
+                    pattern: '^[A-Z]{2}$'
+                company:
+                    description: Company name
+                    type: string
+                    nullable: true
+                gender:
+                    description: Gender
+                    type: string
+                    nullable: true
+                    enum:
+                        - F
+                        - M
+                phone:
+                    description: Phone number
+                    type: string
+                    nullable: true
+                taxNumber:
+                    description: Vat reference number
+                    type: string
+                    nullable: true
+                iban:
+                    description: International Bank Account Number
+                    type: string
+                    format: iban
+                    nullable: true
+                isDefaultForDelivery:
+                    description: Whether this address should be used as delivery address by default
+                    type: boolean
+                isDefaultForInvoice:
+                    description: Whether this address should be used as invoice address by default
+                    type: boolean
+        CustomerAddressPatchable:
+            description: Customer Address
+            properties:
+                firstName:
+                    description: First name
+                    type: string
+                lastName:
+                    description: Last name
+                    type: string
+                street:
+                    description: Street name
+                    type: string
+                streetNumber:
+                    description: Street number (may include suffix)
+                    type: string
+                zipCode:
+                    description: Zip code
+                    type: string
+                city:
+                    description: City
+                    type: string
+                countryCode:
+                    description: ISO 3166-1 alpha-2 country code
+                    type: string
+                    pattern: '^[A-Z]{2}$'
+                company:
+                    description: Company name
+                    type: string
+                    nullable: true
+                gender:
+                    description: Gender
+                    type: string
+                    nullable: true
+                    enum:
+                        - F
+                        - M
+                phone:
+                    description: Phone number
+                    type: string
+                    nullable: true
+                taxNumber:
+                    description: Vat reference number
+                    type: string
+                    nullable: true
+                iban:
+                    description: International Bank Account Number
+                    type: string
+                    format: iban
+                    nullable: true
+                isDefaultForDelivery:
+                    description: Whether this address should be used as delivery address by default
+                    type: boolean
+                isDefaultForInvoice:
+                    description: Whether this address should be used as invoice address by default
+                    type: boolean
+        CustomerAddressPostable:
+            description: Customer Address
+            properties:
+                firstName:
+                    description: First name
+                    type: string
+                lastName:
+                    description: Last name
+                    type: string
+                street:
+                    description: Street name
+                    type: string
+                streetNumber:
+                    description: Street number (may include suffix)
+                    type: string
+                zipCode:
+                    description: Zip code
+                    type: string
+                city:
+                    description: City
+                    type: string
+                countryCode:
+                    description: ISO 3166-1 alpha-2 country code
+                    type: string
+                    pattern: '^[A-Z]{2}$'
+                company:
+                    description: Company name
+                    type: string
+                    nullable: true
+                gender:
+                    description: Gender
+                    type: string
+                    nullable: true
+                    enum:
+                        - F
+                        - M
+                phone:
+                    description: Phone number
+                    type: string
+                    nullable: true
+                taxNumber:
+                    description: Vat reference number
+                    type: string
+                    nullable: true
+                iban:
+                    description: International Bank Account Number
+                    type: string
+                    format: iban
+                    nullable: true
+        InvoiceAddress:
+            description: Invoice address
+            allOf:
+                -   $ref: "#/components/schemas/Address"
+                -   properties:
+                        taxnumber:
+                            description: Vat reference number
+                            type: string
+                        bankaccount:
+                            description: Bankaccount number
+                            type: string
+        Order:
+            required:
+                - number
+                - uuid
+                - date
+                - time
+                - status
+                - debtor
+            properties:
+                number:
+                    description: Ordernumber
+                    type: integer
+                uuid:
+                    description: Order UUID
+                    type: string
+                    format: uuid
+                date:
+                    description: Order date
+                    type: string
+                    format: date
+                time:
+                    description: Order time
+                    type: string
+                status:
+                    description: Order status
+                    type: integer
+                status_changed_date:
+                    description: Date of last status change
+                    type: string
+                    format: date
+                status_changed_time:
+                    description: Time of last status change
+                    type: string
+                weight:
+                    description: Total order weight
+                    type: string
+                archived:
+                    description: Archived status
+                    type: boolean
+                finished:
+                    deprecated: true
+                    description: "Finished status (deprecated: always true)"
+                    type: boolean
+                taxed:
+                    description: VAT added
+                    type: string
+                locale:
+                    description: Order localisation
+                    type: string
+                discountcode:
+                    description: Discountcode
+                    type: string
+                currency:
+                    description: Chosen currency (ISO 4217 code)
+                    type: string
+                currency_format_locale:
+                    description: Chosen currency format locale (ISO 3166-1 alpha-2 code)
+                    type: string
+                credited_order_number:
+                    description: Reference to the original order for which this is a credit order
+                    type: integer
+                credit_order_numbers:
+                    description: Ordernumbers of any linked credit orders
+                comments:
+                    $ref: "#/components/schemas/OrderComment"
+                business_model:
+                    description: Which business model has been applied to the order.
+                        In this case the `company` field will not be empty and the `reference` field is available
+                    type: string
+                    enum:
+                        - B2C
+                        - B2B
+                reference:
+                    description: Order reference for business sales. Only available if business model is `B2B`
+                    type: string
+                    maxLength: 255
+                tax_region:
+                    description: The region that has been used for tax calculations (ISO 3166-1 alpha-2)
+                    type: string
+                    pattern: '^[A-Z]{2}$'
+                tax_strategy:
+                    description: Which tax strategy (if any) has been applied to this order
+                    type: string
+                    enum:
+                        - ''
+                        - zero_percent
+                        - reverse_charged_vat
+                partner:
+                    type: object
+                    properties:
+                        name:
+                            description: Partner name
+                            type: string
+                payment_status:
+                    type: string
+                    deprecated: true
+                    description: Current payment status (`new` |`pending` |
+                        `authorized` | `captured` | `voided` | `refunded` |
+                        `failed` | `incomplete` | `unknown`)
+                        (deprecated in favor of the order payment listing endpoint)
+                payment:
+                    $ref: "#/components/schemas/OrderPaymentSummary"
+                debtor:
+                    $ref: "#/components/schemas/OrderDebtor"
+                price:
+                    type: object
+                    properties:
+                        tax:
+                            description: Amount of applied VAT
+                            oneOf:
+                                -   type: array
+                                    items:
+                                        $ref: "#/components/schemas/TaxPrice"
+                                -   $ref: "#/components/schemas/TaxPrice"
+                        total:
+                            description: Total price (including VAT)
+                            type: string
+                orderlines:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/OrderDetail"
+                shipping:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/OrderShipping"
+            example:
+                number: 27
+                uuid: "af88e19b-a57b-4aae-a92b-f7078454d1e3"
+                date: "2015-11-03"
+                time: "13:37:12"
+                status: 1
+                archived: true
+                finished: false
+                taxed: include
+                locale: en_GB
+                discountcode: korting123
+                comments:
+                    customer: Please send quickly!
+                business_model: B2B
+                reference: MOS103271
+                offline_location_id: 7127e08a-4af0-4fdf-ac7b-157be3345df0
+                currency: EUR
+                credited_order_number: 28
+                credit_order_numbers:
+                    - 99
+                    - 101
+                payment:
+                    gateway_name: "basic"
+                    method_name: "advance"
+                payment_status: captured
+                debtor:
+                    email: support@mijnwebwinkel.nl
+                    address:
+                        invoice:
+                            gender: V
+                            name: Truus voorbeeldig
+                            company: Voorbeeldig BV
+                            street: Molenstraat
+                            number: "62"
+                            zipcode: 5341GE
+                            city: Oss
+                            country: Nederland
+                            country_code: NL
+                            phone: 06-12345678
+                            bankaccount: NL39RABO0300065264
+                price:
+                    tax:
+                        -   amount: 0.830000
+                            rate: 9.00
+                        -   amount: 6.500000
+                            rate: 21.00
+                    total: 47.450000
+                orderlines:
+                    -   id: 8140cf8f-0ef1-4e71-aed0-dc3efc1b46b3
+                        type: article
+                        quantity: 1
+                        weight: 0
+                        description: Article A
+                        price:
+                            amount: 12.396694
+                            amount_including_tax: 15.00
+                            rate: 21.00
+                        articles:
+                            -   id: 1
+                                description: Article A
+                                price:
+                                    amount: 24.793388
+                                    rate: 21.00
+                                options:
+                                    -   description: Action price
+                                        price:
+                                            amount: -12.396694
+                                            rate: 21.00
+                    -   id: 19bc3d68-eea1-41ac-9743-3b1ba58aa5ac
+                        type: article
+                        quantity: 2
+                        weight: 0
+                        description: Article B
+                        price:
+                            amount: 8.181818
+                            amount_including_tax: 9.90
+                            rate: 21.00
+                        articles:
+                            -   id: 2
+                                description: Article B
+                                price:
+                                    amount: 7.396694
+                                    rate: 21.00
+                                options:
+                                    -   description: Action price
+                                        price:
+                                            amount: -3.305785
+                                            rate: 21.00
+                    -   id: 07d24f67-0f98-414d-9dba-61814a09964d
+                        type: article
+                        quantity: 3
+                        weight: 0
+                        description: Article C
+                        price:
+                            amount: 4.834710
+                            amount_including_tax: 5.85
+                            rate: 21.00
+                            articles:
+                                -   id: 3
+                                    description: Article C
+                                    price:
+                                        amount: 1.611570
+                                        rate: 21.00
+                    -   id: 155a7fae-6f09-4444-9bdb-87cf03a7fa1d
+                        type: article
+                        quantity: 5
+                        weight: 0
+                        description: Article D
+                        price:
+                            amount: 8.944950
+                            amount_including_tax: 9.75
+                            rate: 9.00
+                        articles:
+                            -   id: 4
+                                description: Article D
+                                price:
+                                    amount: 1.788990
+                                    rate: 9.00
+                    -   id: d2f57281-7c24-4fd8-b000-caeb3da639db
+                        type: payment
+                        quantity: 1
+                        price:
+                            -   amount: 0.192571
+                                rate: 9.00
+                                amount_including_tax: 0.21
+                            -   amount: 0.652972
+                                rate: 21.00
+                                amount_including_tax: 0.79
+                    -   id: 2fed4cd8-4ad1-440c-9d27-6fb32d2e0eba
+                        type: payment
+                        quantity: 1
+                        price:
+                            amount: 4.917355
+                            amount_including_tax: 5.95
+                            rate: 21.00
+                shipping:
+                    -   country:
+                            description: Nederland
+                            isocode: NL
+        OrderPatchable:
+            properties:
+                archived:
+                    description: Archived status
+                    type: boolean
+                status:
+                    description: Order status
+                    type: integer
+                comments:
+                    $ref: "#/components/schemas/OrderCommentPatchable"
+                reference:
+                    description: Order reference for business sales. Only available if business model is `B2B`
+                    type: string
+                    maxLength: 255
+                offline_location_id:
+                    description: Point of Sale location identifier (Contains null for direct webshop
+                        orders)
+                    type: string
+            example:
+                status: 1
+                archived: true
+                comments:
+                    internal: Owner's commentary
+                reference: MOS1044712
+                offline_location_id: 7127e08a-4af0-4fdf-ac7b-157be3345df0
+        OrderPostable:
+            required:
+                - orderlines
+                - debtor
+            example:
+                status: 1
+                archived: false
+                discountcode: korting123
+                comments:
+                    customer: Please send quickly!
+                business_model: B2C
+                offline_location_id: 7127e08a-4af0-4fdf-ac7b-157be3345df0
+                payment:
+                    gateway_name: mollie
+                    method_name: ideal
+                    status:
+                        id: 1
+                debtor:
+                    email: support@mijnwebwinkel.nl
+                    address:
+                        invoice:
+                            gender: V
+                            name: Truus voorbeeldig
+                            company: ""
+                            street: Molenstraat
+                            number: "62"
+                            zipcode: 5341GE
+                            city: Oss
+                            country_code: NL
+                            phone: 06-12345678
+                            bankaccount: NL39RABO0300065264
+                orderlines:
+                    -   type: article
+                        quantity: 3
+                        articles:
+                            -   id: 3327557
+                                options:
+                                    -   list_option_id: "1537892"
+                                    -   list_option_id: "1538895"
+                    -   type: article
+                        quantity: 1
+                        articles:
+                            -   id: 3327558
+                        price_override: "13.99"
+                    -   type: custom
+                        quantity: 2
+                        description: Omg I'm só special
+                        unit_price:
+                            amount: "8.223140"
+                            rate: "21.00"
+                        unit_weight: "2.2"
+                    -   type: custom
+                        quantity: 1
+                        description: I'm special and have a unit price specified including vat
+                        unit_price:
+                            amount_including_tax: "5.95"
+                            rate: "21.00"
+                        unit_weight: "2.2"
+                shipping_method_id: "2273"
+            allOf:
+                -   $ref: "#/components/schemas/OrderPatchable"
+                -   properties:
+                        discountcode:
+                            description: Discountcode
+                            type: string
+                        business_model:
+                            description: Which business model should be applied to the order. For `B2B` the
+                                `OrderDebtor.address.invoice.company` field must not be empty. For `B2C` the `reference` field is not
+                                available. If this field is omitted the value of `Store.available_business_models` will be used,
+                                defaulting to `B2C` if this setting is `ALL`. If `Store.available_business_models` equals `B2B`,
+                                the `company` field must not be empty.
+                            type: string
+                            enum:
+                                - B2C
+                                - B2B
+                            default: B2C
+                        reference:
+                            description: Order reference for business sales. Only available if business model is `B2B`
+                            type: string
+                            maxLength: 255
+                        debtor:
+                            $ref: "#/components/schemas/OrderDebtor"
+                        payment:
+                            $ref: "#/components/schemas/OrderPaymentSummary"
+                        orderlines:
+                            type: array
+                            items:
+                                $ref: "#/components/schemas/OrderDetailPostable"
+                        shipping_method_id:
+                            description: Shipping method reference
+                            type: string
+                        shipping_type:
+                            description: This defines the shipping type for the order. The order will be identified as delivery or pickup order based on this status. 1 delivery_none, 2 delivery_by_weight, 3 - delivery_by_weight_and_country, 5 - pickup_at_location, 6 - pickup_at_store, 7 - delivery_moment, 8 - delivery_no_costs
+                            type: integer
+                            enum:
+                                - 1
+                                - 2
+                                - 3
+                                - 5
+                                - 6
+                                - 7
+                                - 8
+                            default: 1
+        OrderAddress:
+            required:
+                - invoice
+            properties:
+                invoice:
+                    $ref: "#/components/schemas/InvoiceAddress"
+                delivery:
+                    $ref: "#/components/schemas/Address"
+        OrderArticle:
+            allOf:
+                -   $ref: "#/components/schemas/OrderArticlePostable"
+                -   required:
+                        - rate
+                        - amount
+                -   properties:
+                        description:
+                            description: Article description
+                            type: string
+                        sku:
+                            description: Article SKU
+                            type: string
+                        price:
+                            type: object
+                            properties:
+                                amount:
+                                    description: Amount (excluding tax), may have up to 6 decimals
+                                    type: string
+                                rate:
+                                    description: Tax percentage
+                                    type: string
+                                purchase_price:
+                                    description: Cost of the article for the merchant, if specified
+                                    type: string
+                        options:
+                            type: array
+                            items:
+                                $ref: "#/components/schemas/OrderArticleListOption"
+        OrderArticlePostable:
+            required:
+                - id
+            allOf:
+                -   $ref: "#/components/schemas/BaseOrderArticle"
+                -   properties:
+                        options:
+                            type: array
+                            items:
+                                $ref: "#/components/schemas/OrderArticleListOptionPostable"
+        BaseOrderArticle:
+            properties:
+                id:
+                    description: Internal article id
+                    type: integer
+        OrderArticleDetail:
+            properties:
+                description:
+                    description: Option description
+                    type: string
+                price:
+                    $ref: "#/components/schemas/TaxPrice"
+        OrderArticleListOption:
+            allOf:
+                -   $ref: "#/components/schemas/OrderArticleListOptionPostable"
+                -   properties:
+                        description:
+                            type: string
+                        price:
+                            type: string
+        OrderArticleListOptionPostable:
+            required:
+                - list_option_id
+            properties:
+                list_option_id:
+                    type: integer
+        OrderComment:
+            properties:
+                customer:
+                    description: Comment as added by customer
+                    type: string
+                    readOnly: true
+                internal:
+                    description: Comment as added by merchant
+                    type: string
+        OrderCommentPatchable:
+            properties:
+                internal:
+                    description: Comment as added by merchant
+                    type: string
+        OrderDebtor:
+            description: Order debitor details
+            properties:
+                id:
+                    description: "ID of the corresponding customer, if any"
+                    type: string
+                    format: uuid
+                gender:
+                    deprecated: true
+                    description: "Gender description (deprecated: use [Invoice]Address.gender)"
+                    type: string
+                name:
+                    deprecated: true
+                    description: "Full name (deprecated: use [Invoice]Address.name)"
+                    type: string
+                company:
+                    deprecated: true
+                    description: "Company name (deprecated: use [Invoice]Address.company)"
+                    type: string
+                email:
+                    description: Email address
+                    type: string
+                phone:
+                    deprecated: true
+                    description: "Phone number (deprecated: use [Invoice]Address.phone)"
+                    type: string
+                bankaccount:
+                    deprecated: true
+                    description: "Bankaccount number (deprecated: use InvoiceAddress.bankaccount)"
+                    type: string
+                link_to_account:
+                    description: Link to debitor account
+                    type: boolean
+                address:
+                    $ref: "#/components/schemas/OrderAddress"
+        OrderDetail:
+            allOf:
+                -   $ref: "#/components/schemas/BaseOrderDetail"
+                -   properties:
+                        articles:
+                            description: Required for the 'article' type
+                            type: array
+                            items:
+                                $ref: "#/components/schemas/OrderArticle"
+                        weight:
+                            description: Total weight for all items in this orderline
+                            type: string
+                        description:
+                            description: Article description (including options)
+                            type: string
+                        price:
+                            oneOf:
+                                -   type: array
+                                    items:
+                                        $ref: "#/components/schemas/TaxPrice"
+                                -   $ref: "#/components/schemas/TaxPrice"
+        BaseOrderDetail:
+            required:
+                - type
+                - quantity
+            properties:
+                id:
                     description: Unique identifier
                     type: string
                     format: uuid
-                  type:
-                    description: Line type
+                type:
+                    description: |-
+                        OrderDetail type, one of:
+                        - article
+                        - custom
+                    type: string
+                quantity:
+                    description: Amount of items
+                    type: integer
+                unit_price:
+                    $ref: "#/components/schemas/TaxPrice"
+                unit_weight:
+                    description: Custom item weight per unit; required for custom articles
+                    type: string
+                price_override:
+                    $ref: "#/components/schemas/Price"
+        OrderDetailPostable:
+            allOf:
+                -   $ref: "#/components/schemas/BaseOrderDetail"
+                -   properties:
+                        articles:
+                            description: Required for the 'article' type
+                            type: array
+                            items:
+                                $ref: "#/components/schemas/OrderArticlePostable"
+        OrderPaymentPatchable:
+            description: Order payment
+            required:
+                - method
+            properties:
+                method:
+                    $ref: "#/components/schemas/PaymentMethodListInput"
+                referrerUrl:
+                    $ref: "#/components/schemas/PaymentReferrerUrl"
+                orderLines:
+                    $ref: "#/components/schemas/OrderPaymentLinePortions"
+        OrderPaymentPostable:
+            description: Order payment
+            required:
+                - gateway
+                - method
+            properties:
+                gateway:
+                    $ref: "#/components/schemas/PaymentGatewayListInput"
+                method:
+                    $ref: "#/components/schemas/PaymentMethodListInput"
+                referrerUrl:
+                    $ref: "#/components/schemas/PaymentReferrerUrl"
+                orderLines:
+                    $ref: "#/components/schemas/OrderPaymentLinePortions"
+        OrderPaymentLinePortions:
+            description: Order lines to include in the payment (all lines by default)
+            example:
+                -   id: "5ddd8613-9254-4877-a752-fe97e8fcf26a"
+                    quantity: 3
+                -   id: "71df5adb-81f4-4136-b11b-cef3815a5bff"
+                -   id: "ce51bbf9-f4dc-43f5-88d2-9a1b6948b97b"
+                    quantity: 2
+                    price: 599
+                -   id: "63506cb5-c53a-4fda-a81c-914b1a190293"
+                    price: 1099
+            type: array
+            items:
+                properties:
+                    id:
+                        description: Unique identifier
+                        type: string
+                        format: uuid
+                    quantity:
+                        description: Override amount of items
+                        type: integer
+                    price:
+                        description: Override price in minor currency units (eg cents)
+                        type: integer
+        OrderPaymentSummary:
+            deprecated: true
+            description: Order payment details (available/required if Order.price.total <> 0.00)
+            properties:
+                gateway_name:
+                    $ref: "#/components/schemas/PaymentGatewayList"
+                method_name:
+                    $ref: "#/components/schemas/PaymentMethodList"
+                status:
+                    $ref: "#/components/schemas/OrderPaymentStatus"
+        OrderPaymentStatus:
+            deprecated: true
+            description: Order payment status details
+            properties:
+                id:
+                    description: |-
+                        0: Status unknown
+                        1: Successful
+                        2: Cancelled
+                        3: Failed
+                        4: Expired
+                        5: Pending
+                        6: Refused
+                        7: Refunded
+                    type: integer
+                text:
+                    description: Payment status description
+                    type: string
+        OrderPrice:
+            properties:
+                tax:
+                    description: Vat charge(s)
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/TaxPrice"
+                total:
+                    description: Total order price
+                    type: string
+        OrderShipping:
+            properties:
+                country:
+                    $ref: "#/components/schemas/OrderShippingCountry"
+        OrderStatus:
+            description: Order status details
+            properties:
+                status:
+                    description: Identifier for the order status
+                    type: integer
+                description:
+                    description: Description of the order status
+                    type: string
+                credit_order:
+                    description: True if the status is allowed for (and signifies) a credit order
+                    type: boolean
+            example:
+                status: 1
+                description: Order Pending
+                credit_order: false
+        PaymentGateways:
+            description: List of payment gateways and methods
+            properties:
+                gateways:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/PaymentGateway"
+            example:
+                gateways:
+                    -   name: mollie
+                        displayName: Mollie
+                        websiteUrl: https://www.mollie.com/
+                        methods:
+                            -   name: ideal
+                                displayName: iDEAL
+        PaymentGateway:
+            description: Payment Gateway
+            properties:
+                name:
+                    description: Unique identifying name for the given gateway
+                    type: string
+                displayName:
+                    description: Gateway name for displaying
+                    type: string
+                websiteUrl:
+                    description: Link to the gateways website
+                    type: string
+                methods:
+                    description: List of available methods for the given gateway
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/PaymentMethod"
+        PaymentGatewayList:
+            deprecated: true
+            description: Payment gateway name
+            type: string
+            enum:
+                - "afterpay"
+                - "basic"
+                - "ingenico"
+                - "klarna_checkout"
+                - "mollie"
+                - "mollieOld"
+                - "multisafepay"
+                - "paynl"
+                - "paypal"
+                - "paytor"
+                - "sisow"
+                - "sumup"
+                - "zettle"
+        PaymentGatewayListInput:
+            description: Payment gateway name
+            type: string
+            enum:
+                - "basic"
+                - "klarna_checkout"
+                - "mollie"
+                - "multisafepay"
+                - "paynl"
+                - "paypal"
+                - "sisow"
+                - "sumup"
+                - "zettle"
+        PaymentMethodList:
+            deprecated: true
+            description: Payment method name
+            type: string
+            enum:
+                - "advance"
+                - "afterpay"
+                - "apple_pay"
+                - "bancontact"
+                - "bank_transfer"
+                - "belfius"
+                - "bitcoin"
+                - "card"
+                - "cash"
+                - "creditcard"
+                - "directdebit"
+                - "external"
+                - "giropay"
+                - "ideal"
+                - "ideal:issuer"
+                - "invoice"
+                - "in_arrears"
+                - "kbccbc"
+                - "klarna_checkout"
+                - "klarna_paylater"
+                - "klarna_paynow"
+                - "klarna_sliceit"
+                - "maestro"
+                - "mastercard"
+                - "paypal"
+                - "paysafecard"
+                - "pickup"
+                - "podium_giftcard"
+                - "rembours"
+                - "singledebit"
+                - "sofortbanking"
+                - "visa"
+                - "webshop_giftcard"
+        PaymentMethodListInput:
+            description: Payment method name
+            type: string
+            enum:
+                - "advance"
+                - "afterpay"
+                - "apple_pay"
+                - "bancontact"
+                - "belfius"
+                - "card"
+                - "cash"
+                - "creditcard"
+                - "directdebit"
+                - "external"
+                - "giropay"
+                - "ideal"
+                - "ideal:issuer"
+                - "invoice"
+                - "kbccbc"
+                - "klarna_checkout"
+                - "klarna_paylater"
+                - "klarna_paynow"
+                - "klarna_sliceit"
+                - "maestro"
+                - "mastercard"
+                - "paypal"
+                - "paysafecard"
+                - "pickup"
+                - "rembours"
+                - "singledebit"
+                - "sofortbanking"
+                - "visa"
+                - "webshop_giftcard"
+        PaymentMethod:
+            description: Payment method
+            properties:
+                name:
+                    description: Unique identifying name for the given method
+                    type: string
+                displayName:
+                    description: Localized name of the payment method
+                    type: string
+        StorePaymentGateways:
+            description: List of payment gateways and methods
+            properties:
+                gateways:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/StorePaymentGateway"
+            example:
+                gateways:
+                    -   name: mollie
+                        displayName: Mollie
+                        websiteUrl: https://www.mollie.com/
+                        methods:
+                            -   name: ideal
+                                displayName: iDEAL
+                                settings:
+                                    cost:
+                                        amount: "0.05"
+                                        percentage: "5.87"
+        StorePaymentGateway:
+            description: Payment Gateway
+            properties:
+                name:
+                    description: Unique identifying name for the given gateway
+                    type: string
+                displayName:
+                    description: Gateway name for displaying
+                    type: string
+                websiteUrl:
+                    description: Link to the gateways website
+                    type: string
+                methods:
+                    description: List of available methods for the given gateway
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/StorePaymentMethod"
+        StorePaymentMethod:
+            description: Payment method
+            properties:
+                name:
+                    description: Unique identifying name for the given method
+                    type: string
+                displayName:
+                    description: Localized name of the payment method
+                    type: string
+                settings:
+                    description: List of settings for the given method, specific for the
+                        given store
+                    type: object
+                    properties:
+                        cost:
+                            description: Charge per transaction for the given method, can be
+                                a combination of fixed and percentual
+                            type: object
+                            properties:
+                                amount:
+                                    description: Fixed charge per transaction
+                                    type: string
+                                percentage:
+                                    description: Percentual charge per transaction
+                                    type: string
+        OrderShippingCountry:
+            description: Order shipping country settings
+            properties:
+                description:
+                    description: Country description
+                    type: string
+                isocode:
+                    description: Country iso code
+                    type: string
+        TaxPolicyRegion:
+            description: Tax policy region
+            example:
+                regionCode: NL
+                taxEnabled: true
+                taxNumber: NL000099998B57
+                taxRate: 0.21
+                shippingTaxMethod: "fixed"
+                shippingTaxRate: 0.21
+                transactionTaxMethod: "proportional"
+                transactionTaxRate: null
+                overrides:
+                    -   taxRate: 0.06
+                        items:
+                            -   type: product
+                                references: [ product-1, product-3 ]
+            properties:
+                regionCode:
+                    description: Country code (ISO 3166-1 alpha-2)
+                    type: string
+                    pattern: '^[A-Z]{2}$'
+                taxEnabled:
+                    description: Whether tax is enabled
+                    type: boolean
+                taxNumber:
+                    description: The tax number/ID, currently only supports EU VAT number
+                    type: string
+                    format: vat-number
+                    nullable: true
+                taxRate:
+                    description: The general tax rate
+                    type: string
+                    format: float
+                    minimum: 0
+                    maximum: 1
+                    nullable: true
+                shippingTaxMethod:
+                    description: What method is being used to calculate shipping tax
                     type: string
                     enum:
-                      - "digital"
-                      - "discount"
-                      - "gift_card"
-                      - "payment_fee"
-                      - "physical"
-                      - "sales_tax"
-                      - "shipping_fee"
-                      - "store_credit"
-                      - "surcharge"
-                  name:
-                    description: Name
+                        - 'fixed'
+                        - 'proportional'
+                shippingTaxRate:
+                    description: Shipping tax rate
                     type: string
-                  description:
-                    description: Description
+                    format: float
+                    minimum: 0
+                    maximum: 1
+                    nullable: true
+                transactionTaxMethod:
+                    description: What method is being used to calculate transaction tax
                     type: string
-                  quantity:
-                    description: Quantity
+                    enum:
+                        - 'fixed'
+                        - 'proportional'
+                transactionTaxRate:
+                    description: Transaction tax rate
                     type: string
-                  price:
+                    format: float
+                    minimum: 0
+                    maximum: 1
+                    nullable: true
+                overrides:
+                    description: Tax overrides
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/TaxPolicyRegionOverride'
+        TaxPolicyRegionOverride:
+            description: Tax policy region override
+            properties:
+                taxRate:
+                    description: Tax rate for override
+                    type: string
+                    format: float
+                    minimum: 0
+                    maximum: 1
+                items:
+                    description: Override items
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/TaxPolicyOverride'
+            required:
+                - taxRate
+                - items
+        TaxPolicyOverride:
+            description: Tax policy override
+            properties:
+                type:
+                    description: What kind of override
+                    type: string
+                    enum:
+                        - 'product'
+                        - 'collection'
+                references:
+                    description: List of references this override applies to
+                    type: array
+                    items:
+                        description: Identifier of overridden item
+                        type: string
+            required:
+                - type
+                - references
+        TaxPrice:
+            required:
+                - rate
+            properties:
+                rate:
+                    description: Vat percentage
+                    type: string
+                amount:
+                    description: Amount (excluding tax), may have up to 6 decimals
+                    type: string
+                amount_including_tax:
+                    description: Amount (including tax) with exactly 2 decimals.
+                        May be used for POST operation with custom items,
+                        where either amount or amount_including_tax must be specified
+                    type: string
+        Price:
+            description: Price (in decimal notation)
+            type: string
+        Error:
+            description: Error response
+            properties:
+                code:
+                    description: Unique error code
+                    type: integer
+                message:
+                    description: Short error message
+                    type: string
+                description:
+                    description: Extended error information
+                    type: string
+        Discountcode:
+            allOf:
+                -   properties:
+                        id:
+                            description: Discountcode identifier
+                            type: string
+                            format: uuid
+                        customer_id:
+                            description: Identifier of the customer the discountcode is valid for
+                            nullable: true
+                            type: string
+                            format: uuid
+                -   $ref: '#/components/schemas/DiscountcodePostable'
+            example:
+                id: 'ac941823-9b4a-492a-9157-4c7124419fa1'
+                code: 'christmas-sale-1337'
+                customer_id: 'f7ec4a49-3e8a-436d-9b32-5f3cf6a8ac3a'
+                description: 'Christmas 2017'
+                percentage_discount: '10.00'
+                fixed_discount: '2.50'
+                minimum_order_price: '100.00'
+                minimum_products: 3
+                applies_to_shipping: false
+                free_shipping: false
+                applies_to_action_prices: false
+                single_use: false
+                active: true
+                valid_from: '2017-12-01'
+                valid_until: '2017-12-26'
+                valid_products:
+                    -   product_id: '7494373'
+                    -   product_id: '3760904'
+                        max_quantity: 3
+        DiscountcodePatchable:
+            $ref: '#/components/schemas/DiscountcodePostable'
+        DiscountcodePostable:
+            properties:
+                code:
+                    description: Unique identifying code for the discountcode
+                    type: string
+                    maxLength: 20
+                description:
+                    description: Description of the discountcode (internal)
+                    type: string
+                percentage_discount:
+                    description: Percentual discount which is applied
+                    type: string
+                fixed_discount:
+                    description: Fixed amount of discount which is applied
+                    type: string
+                minimum_order_price:
+                    description: Minimum total price of valid articles in the order for the
+                        discountcode to be valid
+                    type: string
+                minimum_products:
+                    description: Minimum number of products in the order for the discountcode to be
+                        valid
+                    type: integer
+                applies_to_shipping:
+                    description: Fixed discount may also apply to shipping costs
+                    type: boolean
+                free_shipping:
+                    description: All shipping costs are discounted
+                    type: boolean
+                applies_to_action_prices:
+                    description: Discountcode is valid for articles with an action price
+                    type: boolean
+                single_use:
+                    description: Discountcode can be used only once
+                    type: boolean
+                active:
+                    description: Discountcode is active
+                    type: boolean
+                valid_from:
+                    description: Date the discountcode is valid from
+                    type: string
+                    format: date
+                valid_until:
+                    description: Date the discountcode is valid until
+                    type: string
+                    format: date
+                valid_article_ids:
+                    deprecated: true
+                    description: 'Specific article identifiers the discountcode is valid for (deprecated: use valid_products)'
+                    type: array
+                    items:
+                        type: string
+                valid_product_ids:
+                    description: Specific products the discountcode is valid for
+                    type: array
+                    items:
+                        properties:
+                            product_id:
+                                description: Identifier of the product the discountcode is valid for
+                                type: string
+                            max_quantity:
+                                description: Maximum number of times the discountcode is valid for this product
+                                type: integer
+                invalid_article_ids:
+                    deprecated: true
+                    description: 'Specific article identifiers the discountcode is not valid for (deprecated: use invalid_product_ids)'
+                    type: array
+                    items:
+                        type: string
+                invalid_product_ids:
+                    description: Specific product identifiers the discountcode is not valid for
+                    type: array
+                    items:
+                        type: string
+                valid_category_ids:
+                    description: Specific category identifiers the discountcode is valid for
+                    type: array
+                    items:
+                        type: string
+                invalid_category_ids:
+                    description: Specific category identifiers the discountcode is not valid for
+                    type: array
+                    items:
+                        type: string
+            example:
+                description: 'Christmas 2017'
+                percentage_discount: '10.00'
+                fixed_discount: '2.50'
+                minimum_order_price: '100.00'
+                minimum_products: 3
+                applies_to_shipping: false
+                free_shipping: false
+                applies_to_action_prices: false
+                single_use: false
+                active: true
+                valid_from: '2017-12-01'
+                valid_until: '2017-12-26'
+                valid_products:
+                    -   product_id: '7494373'
+                    -   product_id: '3760904'
+                        max_quantity: 3
+        NewsletterSubscriber:
+            example:
+                email: alberto@studio100.be
+                name: Alberto Vermicelli
+                activated: false
+                created_date: "2016-07-04"
+                created_time: "13:37:00"
+                updated_date: "2016-07-25"
+                updated_time: "13:37:00"
+            allOf:
+                -   $ref: "#/components/schemas/NewsletterSubscriberPatchable"
+                -   properties:
+                        email:
+                            description: Subscriber email-address
+                            type: string
+                        activated:
+                            description: Subscriber has been activated (confirmed)
+                            type: boolean
+                        created_date:
+                            description: Subscriber creation date
+                            type: string
+                            format: date
+                        created_time:
+                            description: Subscriber creation time. Will be merged in `created_date` in
+                                future version
+                            type: string
+                            format: time
+                        updated_date:
+                            description: Subscriber last updated date
+                            type: string
+                            format: date
+                        updated_time:
+                            description: Subscriber last updated time. Will be merged in `updated_date`
+                                in future version
+                            type: string
+                            format: time
+        NewsletterSubscriberPostable:
+            example:
+                name: Alberto Vermicelli
+                email: alberto@studio100.be
+            allOf:
+                -   $ref: "#/components/schemas/NewsletterSubscriberPatchable"
+                -   properties:
+                        email:
+                            description: Subscriber email-address
+                            type: string
+        NewsletterSubscriberPatchable:
+            properties:
+                name:
+                    description: Subscriber name
+                    type: string
+            example:
+                name: Alberto Vermicelli
+        OfflineLocation:
+            example:
+                id: 7127e08a-4af0-4fdf-ac7b-157be3345df0
+                name: "Store location Oss: Register 2"
+                street: Molenstraat
+                street_number: "62"
+                zipcode: 5341GE
+                city: Oss
+                country: Netherlands
+                country_code: NL
+                phone: 06-12345678
+                email: support@mijnwebwinkel.nl
+                note: Open from 09:00 till 17:00
+                deleted: false
+            allOf:
+                -   $ref: "#/components/schemas/OfflineLocationPatchable"
+                -   properties:
+                        id:
+                            description: Offline location identifier (UUID string)
+                            type: string
+                        country:
+                            description: Country name
+                            type: string
+        OfflineLocationPatchable:
+            properties:
+                name:
+                    description: Point of sale name
+                    type: string
+                    maxLength: 80
+                street:
+                    description: Point of sale address (street)
+                    type: string
+                    maxLength: 255
+                street_number:
+                    description: Point of sale address (street number)
+                    type: string
+                    maxLength: 20
+                zipcode:
+                    description: Point of sale zipcode
+                    type: string
+                    maxLength: 10
+                city:
+                    description: Point of sale city
+                    type: string
+                    maxLength: 100
+                country_code:
+                    description: ISO 3166-1 alpha-2 code
+                    type: string
+                phone:
+                    description: Point of sale phonenumber (E164 format)
+                    type: string
+                    maxLength: 15
+                email:
+                    description: Point of sale emailaddress
+                    type: string
+                    maxLength: 255
+                note:
+                    description: Additional notes for merchant
+                    type: string
+                    maxLength: 255
+                deleted:
+                    description: Point of sale location is inactive (soft deleted)
+                    type: boolean
+            example:
+                name: "Store location Oss: Register 2"
+                street: Molenstraat
+                street_number: "62"
+                zipcode: 5341GE
+                city: Oss
+                country_code: NL
+                phone: 06-12345678
+                email: support@mijnwebwinkel.nl
+                note: Open from 09:00 till 17:00
+                deleted: false
+        Payment:
+            example:
+                id: 8c1ed7ea-c19a-4137-8517-7d3f580b3b97
+                gateway: mollie
+                method: ideal:ideal_INGBNL2A
+                gatewayReference: ord_8yalb
+                price: 5339
+                currency: EUR
+                storeId: 494c24a3-2243-484a-a81e-b3098d4dc870
+                reference: 33eea580-2381-44bf-b355-d99a13d4f770
+                isTest: false
+                createdAt: 2021-06-29T14:41:26+02:00
+                updatedAt: 2021-06-29T14:41:26+02:00
+                mutations: [
+                    {
+                        id: 196,
+                        type: authorize,
+                        reference: null,
+                        price: 5339,
+                        description: null,
+                        createdAt: 2022-01-18T12:35:27+01:00,
+                        expiresAt: null
+                    },
+                    {
+                        id: 198,
+                        type: capture,
+                        reference: null,
+                        price: 5339,
+                        description: null,
+                        createdAt: 2022-01-18T12:35:27+01:00,
+                        expiresAt: null
+                    }
+                ]
+                order:
+                    id: c5ef58b5-3cd7-4fcc-9d73-9c4c8b39dc31
+                    reference: 2342
+                    price: 5339
+                    tax: 927
+                    locale: nl_NL
+                    deliveryType: delivery
+                    lines: [
+                        {
+                            id: 7a6a2405-d8fe-40e0-809f-6b3a8a48e3de,
+                            type: physical,
+                            name: Fusce eget turpis,
+                            description: Aliquam sed eros non massa malesuada condimentum in sit amet eros.,
+                            quantity: 1,
+                            price: 4839,
+                            tax: 840,
+                            taxRate: "0.2100"
+                        },
+                        {
+                            id: f5acaf51-33ab-47b8-b853-6560ee4b8ec9,
+                            type: shipping_fee,
+                            name: Shipping costs,
+                            description: Shipping costs,
+                            quantity: 1,
+                            price: 500,
+                            tax: 87,
+                            taxRate: "0.2107"
+                        }
+                    ]
+                    customer:
+                        id: ded42190-7f99-4439-b94d-e04c12efcaff
+                        email: foo@example.org
+                        birthDate: null
+                        iban: null
+                        ip: 192.168.16.1
+                        billingAddress:
+                            id: 932c7e56-9de8-4cde-bc79-5d3e78bc6897
+                            name:
+                                first: John
+                                last: Doe
+                            company: MyOnlineStore B.V.
+                            street:
+                                name: Molenstraat
+                                number: 56
+                                suffix: null
+                            zipCode: 5341 GE
+                            city: Oss
+                            country: NL
+                            phone: "+31412668011"
+                            gender: null
+                        shippingAddress:
+                            id: ded42190-7f99-4439-b94d-e04c12efcaff
+                            email: foo@example.org
+                            birthDate: null
+                            iban: null
+                            ip: 192.168.16.1
+                            billingAddress:
+                                id: f1bc2de0-cb7b-4e25-a278-db8a00c157ae
+                                name:
+                                    first: John
+                                    last: Doe
+                                company: MyOnlineStore B.V.
+                                street:
+                                    name: Molenstraat
+                                    number: 56
+                                    suffix: null
+                                zipCode: 5341 GE
+                                city: Oss
+                                country: NL
+                                phone: "+31412668011"
+                                gender: null
+                properties:
+                    minimum_age: 18
+                    shipping_region: NL
+                    validation_callback_url: https://www.example.org/checkout/api/v1/orders/adbac24c-0f4b-4dbf-8aac-beecbfc3ee30/validate
+            properties:
+                id:
+                    description: Unique identifier
+                    type: string
+                    format: uuid
+                gateway:
+                    $ref: "#/components/schemas/PaymentGatewayList"
+                method:
+                    description: Payment method
+                    type: string
+                gatewayReference:
+                    description: Gateway reference
+                    type: string
+                price:
                     description: Price in minor units
                     type: integer
-                  tax:
-                    description: Tax price in minor units
-                    type: integer
-                  taxRate:
-                    description: Tax rate (in decimals)
+                currency:
+                    description: Currency (ISO 4217 code)
                     type: string
-            customer:
-              description: Customer details
-              type: object
-              properties:
+                storeId:
+                    description: Store unique identifier
+                    type: string
+                    format: uuid
+                reference:
+                    description: Unique reference
+                    type: string
+                    format: uuid
+                referrerUrl:
+                    $ref: "#/components/schemas/PaymentReferrerUrl"
+                isTest:
+                    description: Is a test payment
+                    type: boolean
+                createdAt:
+                    description: Payment creation date
+                    type: string
+                    format: date-time
+                updatedAt:
+                    description: Payment last updated date
+                    type: string
+                    format: date-time
+                    nullable: true
+                mutations:
+                    description: Payment mutations
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/PaymentMutation'
+                order:
+                    description: Payment order details
+                    type: object
+                    properties:
+                        id:
+                            description: Unique identifier
+                            type: string
+                            format: uuid
+                        reference:
+                            description: The order number
+                            type: string
+                        price:
+                            description: Price in minor units
+                            type: integer
+                        tax:
+                            description: Tax price in minor units
+                            type: integer
+                        locale:
+                            description: Language of the order contents (ISO 3166-1 alpha-2 code)
+                            type: string
+                        deliveryType:
+                            description: Delivery type
+                            type: string
+                            enum:
+                                - "pickup"
+                                - "delivery"
+                        lines:
+                            type: array
+                            items:
+                                properties:
+                                    id:
+                                        description: Unique identifier
+                                        type: string
+                                        format: uuid
+                                    type:
+                                        description: Line type
+                                        type: string
+                                        enum:
+                                            - "digital"
+                                            - "discount"
+                                            - "gift_card"
+                                            - "payment_fee"
+                                            - "physical"
+                                            - "sales_tax"
+                                            - "shipping_fee"
+                                            - "store_credit"
+                                            - "surcharge"
+                                    name:
+                                        description: Name
+                                        type: string
+                                    description:
+                                        description: Description
+                                        type: string
+                                    quantity:
+                                        description: Quantity
+                                        type: string
+                                    price:
+                                        description: Price in minor units
+                                        type: integer
+                                    tax:
+                                        description: Tax price in minor units
+                                        type: integer
+                                    taxRate:
+                                        description: Tax rate (in decimals)
+                                        type: string
+                        customer:
+                            description: Customer details
+                            type: object
+                            properties:
+                                id:
+                                    description: Customer identifier
+                                    type: string
+                                    format: uuid
+                                email:
+                                    description: Email address
+                                    type: string
+                                    format: email
+                                birthDate:
+                                    description: Date of birth (yyyy-mm-dd)
+                                    type: string
+                                    nullable: true
+                                    format: date
+                                iban:
+                                    description: International Bank Account Number
+                                    type: string
+                                    format: iban
+                                    nullable: true
+                                ip:
+                                    description: IP address
+                                    type: string
+                                billingAddress:
+                                    description: Billing address of the customer
+                                    type: object
+                                    properties:
+                                        id:
+                                            description: Address identifier
+                                            type: string
+                                            format: uuid
+                                        name:
+                                            properties:
+                                                first:
+                                                    description: First name
+                                                    type: string
+                                                last:
+                                                    description: Last name
+                                                    type: string
+                                        company:
+                                            description: Company name
+                                            type: string
+                                            nullable: true
+                                        street:
+                                            properties:
+                                                name:
+                                                    description: Street name
+                                                    type: string
+                                                number:
+                                                    description: Street number
+                                                    type: string
+                                                suffix:
+                                                    description: Street number suffix
+                                                    type: string
+                                                    nullable: true
+                                        zipCode:
+                                            description: Zip code
+                                            type: string
+                                        city:
+                                            description: City
+                                            type: string
+                                        country:
+                                            description: ISO 3166-1 alpha-2 country code
+                                            type: string
+                                            pattern: '^[A-Z]{2}$'
+                                        phone:
+                                            description: Phone number
+                                            type: string
+                                            nullable: true
+                                        gender:
+                                            description: Gender
+                                            type: string
+                                            nullable: true
+                                            enum:
+                                                - F
+                                                - M
+                                invoiceAddress:
+                                    description: Invoice address of the customer
+                                    type: object
+                                    properties:
+                                        id:
+                                            description: Address identifier
+                                            type: string
+                                            format: uuid
+                                        firstName:
+                                            description: First name
+                                            type: string
+                                        lastName:
+                                            description: Last name
+                                            type: string
+                                        company:
+                                            description: Company name
+                                            type: string
+                                            nullable: true
+                                        street:
+                                            properties:
+                                                name:
+                                                    description: Street name
+                                                    type: string
+                                                number:
+                                                    description: Street number
+                                                    type: string
+                                                suffix:
+                                                    description: Street number suffix
+                                                    type: string
+                                                    nullable: true
+                                            nullable: true
+                                        zipCode:
+                                            description: Zip code
+                                            type: string
+                                        city:
+                                            description: City
+                                            type: string
+                                        country:
+                                            description: ISO 3166-1 alpha-2 country code
+                                            type: string
+                                            pattern: '^[A-Z]{2}$'
+                                        phone:
+                                            description: Phone number
+                                            type: string
+                                            nullable: true
+                                        gender:
+                                            description: Gender
+                                            type: string
+                                            nullable: true
+                                            enum:
+                                                - F
+                                                - M
+                properties:
+                    description: Payment properties
+                    type: object
+                    additionalProperties: { }
+        PaymentMutation:
+            example:
+                id: "1"
+                type: "authorize"
+                reference: null
+                price: "499"
+                description: null
+                createdAt: "2021-06-29T14:41:26+02:00"
+                expiresAt: null
+            properties:
                 id:
-                  description: Customer identifier
-                  type: string
-                  format: uuid
+                    description: Mutation ID
+                    type: number
+                type:
+                    description: Mutation type
+                    type: string
+                    enum:
+                        - "authorize"
+                        - "capture"
+                        - "failed"
+                        - "refund"
+                        - "void"
+                reference:
+                    description: Mutation reference
+                    type: string
+                    nullable: true
+                price:
+                    description: Price in minor units
+                    type: number
+                description:
+                    description: Mutation description
+                    type: string
+                    nullable: true
+                createdAt:
+                    description: Mutation creation date
+                    type: string
+                    format: date-time
+                expiresAt:
+                    description: Mutation expiration date
+                    type: string
+                    format: date-time
+                    nullable: true
+        PaymentReferrerUrl:
+            description: Return URL (store landing page by default)
+            type: string
+        CreditOrderPostable:
+            required:
+                - credited_order_number
+                - status
+                - orderlines
+            properties:
+                credited_order_number:
+                    description: Ordernumber for which a credit order should be created
+                    type: string
+                status:
+                    description: Order status, see Order statuses GET for valid values
+                    type: integer
+                archived:
+                    description: Archived status
+                    type: boolean
+                comments:
+                    $ref: "#/components/schemas/OrderComment"
+                orderlines:
+                    description: Items to be returned. Quantities should be specified positive
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/OrderDetailPostable"
+                payment_costs:
+                    description: >-
+                        Payment costs (excluding VAT) to be returned.
+                         * If omitted, payment costs of the original order will be credited. To credit no payment costs, specify 0.
+                         * Payments costs may not be higher than the original costs.
+                         * If all items in the original order are credited, payment costs must be fully credited.
+                    type: string
+                shipping_costs:
+                    description: >-
+                        Shipping costs (excluding VAT) to be returned.
+                         * If omitted, shipping costs of the original order will be credited. To credit no shipping costs, specify 0.
+                         * Shipping costs may not be higher than the original costs.
+                         * If all items in the original order are credited, shipping costs must be fully credited.
+                    type: string
+                offline_location_id:
+                    description: Point of Sale location identifier
+                    type: string
+                    format: uuid
+            example:
+                credited_order_number: "272"
+                status: 10
+                archived: false
+                comments:
+                    customer: The dress did not fit me after all
+                    internal: Returned in physical store
+                orderlines:
+                    -   type: article
+                        quantity: 1
+                        articles:
+                            -   id: 3327557
+                                options:
+                                    -   list_option_id: "330830"
+                    -   type: custom
+                        quantity: 1
+                        description: Special weekly cash register offer
+                        unit_price:
+                            amount: "1.95"
+                            rate: "21.00"
+                shipping_costs: "3.14"
+                payment_costs: "0.31"
+                offline_location_id: 7127e08a-4af0-4fdf-ac7b-157be3345df0
+        ShippingMethod:
+            properties:
+                id:
+                    description: Unique identifier
+                    type: string
+                display_name:
+                    description: Shipping method name as shown in checkout
+                    type: string
+                countries:
+                    description: List of possible country codes (ISO 3166-1 alpha-2)
+                default:
+                    description: Default shipping method for the store
+                    type: boolean
+                no_costs_above:
+                    description: No shipping costs if order subtotal is above this threshold
+                    type: boolean
+            example:
+                display name: Nederland pakketpost
+                countries:
+                    - NL
+                default: true
+                no_costs_above: "100.00"
+        Store:
+            properties:
+                id:
+                    description: Unique identifier
+                    type: string
+                    format: uuid
+                name:
+                    description: Store name
+                    type: string
+                primary_domain:
+                    description: Primary store domain (for the given language)
+                    type: string
+                description:
+                    description: Store description
+                    type: string
+                open:
+                    description: Store is open for visitors
+                    type: boolean
+                version:
+                    description: Store subscription type
+                    type: string
+                administration_language:
+                    description: Language used in the store backend
+                    type: string
+                currency:
+                    description: Chosen currency (ISO 4217 code)
+                    type: string
+                prices_include_tax:
+                    description: Prices are shown including tax
+                    type: boolean
+                default_language:
+                    description: The default language for the store visitors
+                    type: string
+                active_languages:
+                    description: Active languages visitors can choose from
                 email:
-                  description: Email address
-                  type: string
-                  format: email
-                birthDate:
-                  description: Date of birth (yyyy-mm-dd)
-                  type: string
-                  nullable: true
-                  format: date
-                iban:
-                  description: International Bank Account Number
-                  type: string
-                  format: iban
-                  nullable: true
-                ip:
-                  description: IP address
-                  type: string
-                billingAddress:
-                  description: Billing address of the customer
-                  type: object
-                  properties:
-                    id:
-                      description: Address identifier
-                      type: string
-                      format: uuid
-                    name:
-                      properties:
-                        first:
-                          description: First name
-                          type: string
-                        last:
-                          description: Last name
-                          type: string
-                    company:
-                      description: Company name
-                      type: string
-                      nullable: true
-                    street:
-                      properties:
-                        name:
-                          description: Street name
-                          type: string
-                        number:
-                          description: Street number
-                          type: string
-                        suffix:
-                          description: Street number suffix
-                          type: string
-                          nullable: true
-                    zipCode:
-                      description: Zip code
-                      type: string
-                    city:
-                      description: City
-                      type: string
-                    country:
-                      description: ISO 3166-1 alpha-2 country code
-                      type: string
-                      pattern: '^[A-Z]{2}$'
-                    phone:
-                      description: Phone number
-                      type: string
-                      nullable: true
-                    gender:
-                      description: Gender
-                      type: string
-                      nullable: true
-                      enum:
-                        - F
-                        - M
-                invoiceAddress:
-                  description: Invoice address of the customer
-                  type: object
-                  properties:
-                    id:
-                      description: Address identifier
-                      type: string
-                      format: uuid
-                    firstName:
-                      description: First name
-                      type: string
-                    lastName:
-                      description: Last name
-                      type: string
-                    company:
-                      description: Company name
-                      type: string
-                      nullable: true
-                    street:
-                      properties:
-                        name:
-                          description: Street name
-                          type: string
-                        number:
-                          description: Street number
-                          type: string
-                        suffix:
-                          description: Street number suffix
-                          type: string
-                          nullable: true
-                      nullable: true
-                    zipCode:
-                      description: Zip code
-                      type: string
-                    city:
-                      description: City
-                      type: string
-                    country:
-                      description: ISO 3166-1 alpha-2 country code
-                      type: string
-                      pattern: '^[A-Z]{2}$'
-                    phone:
-                      description: Phone number
-                      type: string
-                      nullable: true
-                    gender:
-                      description: Gender
-                      type: string
-                      nullable: true
-                      enum:
-                        - F
-                        - M
-        properties:
-          description: Payment properties
-          type: object
-          additionalProperties: {}
-    PaymentMutation:
-      example:
-        id: "1"
-        type: "authorize"
-        reference: null
-        price: "499"
-        description: null
-        createdAt: "2021-06-29T14:41:26+02:00"
-        expiresAt: null
-      properties:
-        id:
-          description: Mutation ID
-          type: number
-        type:
-          description: Mutation type
-          type: string
-          enum:
-            - "authorize"
-            - "capture"
-            - "failed"
-            - "refund"
-            - "void"
-        reference:
-          description: Mutation reference
-          type: string
-          nullable: true
-        price:
-          description: Price in minor units
-          type: number
-        description:
-          description: Mutation description
-          type: string
-          nullable: true
-        createdAt:
-          description: Mutation creation date
-          type: string
-          format: date-time
-        expiresAt:
-          description: Mutation expiration date
-          type: string
-          format: date-time
-          nullable: true
-    PaymentReferrerUrl:
-      description: Return URL (store landing page by default)
-      type: string
-    CreditOrderPostable:
-      required:
-        - credited_order_number
-        - status
-        - orderlines
-      properties:
-        credited_order_number:
-          description: Ordernumber for which a credit order should be created
-          type: string
-        status:
-          description: Order status, see Order statuses GET for valid values
-          type: integer
-        archived:
-          description: Archived status
-          type: boolean
-        comments:
-          $ref: "#/components/schemas/OrderComment"
-        orderlines:
-          description: Items to be returned. Quantities should be specified positive
-          type: array
-          items:
-            $ref: "#/components/schemas/OrderDetailPostable"
-        payment_costs:
-          description: >-
-            Payment costs (excluding VAT) to be returned.
-             * If omitted, payment costs of the original order will be credited. To credit no payment costs, specify 0.
-             * Payments costs may not be higher than the original costs.
-             * If all items in the original order are credited, payment costs must be fully credited.
-          type: string
-        shipping_costs:
-          description: >-
-            Shipping costs (excluding VAT) to be returned.
-             * If omitted, shipping costs of the original order will be credited. To credit no shipping costs, specify 0.
-             * Shipping costs may not be higher than the original costs.
-             * If all items in the original order are credited, shipping costs must be fully credited.
-          type: string
-        offline_location_id:
-          description: Point of Sale location identifier
-          type: string
-          format: uuid
-      example:
-        credited_order_number: "272"
-        status: 10
-        archived: false
-        comments:
-          customer: The dress did not fit me after all
-          internal: Returned in physical store
-        orderlines:
-          - type: article
-            quantity: 1
-            articles:
-              - id: 3327557
-                options:
-                  - list_option_id: "330830"
-          - type: custom
-            quantity: 1
-            description: Special weekly cash register offer
-            unit_price:
-              amount: "1.95"
-              rate: "21.00"
-        shipping_costs: "3.14"
-        payment_costs: "0.31"
-        offline_location_id: 7127e08a-4af0-4fdf-ac7b-157be3345df0
-    ShippingMethod:
-      properties:
-        id:
-          description: Unique identifier
-          type: string
-        display_name:
-          description: Shipping method name as shown in checkout
-          type: string
-        countries:
-          description: List of possible country codes (ISO 3166-1 alpha-2)
-        default:
-          description: Default shipping method for the store
-          type: boolean
-        no_costs_above:
-          description: No shipping costs if order subtotal is above this threshold
-          type: boolean
-      example:
-        display name: Nederland pakketpost
-        countries:
-          - NL
-        default: true
-        no_costs_above: "100.00"
-    Store:
-      properties:
-        id:
-          description: Unique identifier
-          type: string
-          format: uuid
-        name:
-          description: Store name
-          type: string
-        primary_domain:
-          description: Primary store domain (for the given language)
-          type: string
-        description:
-          description: Store description
-          type: string
-        open:
-          description: Store is open for visitors
-          type: boolean
-        version:
-          description: Store subscription type
-          type: string
-        administration_language:
-          description: Language used in the store backend
-          type: string
-        currency:
-          description: Chosen currency (ISO 4217 code)
-          type: string
-        prices_include_tax:
-          description: Prices are shown including tax
-          type: boolean
-        default_language:
-          description: The default language for the store visitors
-          type: string
-        active_languages:
-          description: Active languages visitors can choose from
-        email:
-          description: Merchant email address (special access required)
-          type: string
-        currency_format_locale:
-          description: Chosen currency format locale (ISO 3166-1 alpha-2 code)
-          type: string
-        available_business_models:
-          description: Which business models can be applied to orders in this store
-          type: string
-          enum:
-            - B2C
-            - B2B
-            - ALL
-        region_code:
-          description: Region where the store is located (ISO 3166-1 alpha-2 country code)
-          type: string
-          pattern: '^[A-Z]{2}$'
-      example:
-        id: e5fc33df-b2bf-40ec-8d8d-56fc34b495cc
-        name: knickknacks
-        primary_domain: https://www.knickknacks.be
-        description: Nice stuff of very high quality
-        open: true
-        version: Pro
-        administration_language: nl_NL
-        currency: EUR
-        prices_include_tax: false
-        default_language: nl_NL
-        active_languages:
-          - nl_NL
-          - en_US
-          - de_DE
-        currency_format_locale: nl_NL
-        available_business_models: B2C
-    ApiProblem:
-      properties:
-        type:
-          description: Type of error
-          type: string
-        title:
-          description: Title of the error
-          type: string
-        detail:
-          description: Description of the error
-          type: string
-        status:
-          description: Statuscode
-          type: integer
+                    description: Merchant email address (special access required)
+                    type: string
+                currency_format_locale:
+                    description: Chosen currency format locale (ISO 3166-1 alpha-2 code)
+                    type: string
+                available_business_models:
+                    description: Which business models can be applied to orders in this store
+                    type: string
+                    enum:
+                        - B2C
+                        - B2B
+                        - ALL
+                region_code:
+                    description: Region where the store is located (ISO 3166-1 alpha-2 country code)
+                    type: string
+                    pattern: '^[A-Z]{2}$'
+            example:
+                id: e5fc33df-b2bf-40ec-8d8d-56fc34b495cc
+                name: knickknacks
+                primary_domain: https://www.knickknacks.be
+                description: Nice stuff of very high quality
+                open: true
+                version: Pro
+                administration_language: nl_NL
+                currency: EUR
+                prices_include_tax: false
+                default_language: nl_NL
+                active_languages:
+                    - nl_NL
+                    - en_US
+                    - de_DE
+                currency_format_locale: nl_NL
+                available_business_models: B2C
+        ApiProblem:
+            properties:
+                type:
+                    description: Type of error
+                    type: string
+                title:
+                    description: Title of the error
+                    type: string
+                detail:
+                    description: Description of the error
+                    type: string
+                status:
+                    description: Statuscode
+                    type: integer

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1207,7 +1207,7 @@ paths:
                 -   $ref: "#/components/parameters/language-path"
                 -   $ref: "#/components/parameters/format"
             responses:
-                "200":
+                200:
                     description: A list of page sections.
                     content:
                         application/json:
@@ -1220,6 +1220,86 @@ paths:
                                 type: array
                                 items:
                                     $ref: "#/components/schemas/PageSection"
+        put:
+            tags:
+                - Page Sections
+            description: |
+                Saves the content and order of page sections for a single page.
+                
+                Be careful, as the data provided will overwrite existing page section data.
+            operationId: savePageSections
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   name: category_id
+                    in: path
+                    description: The page's unique ID.
+                    required: true
+                    schema:
+                        type: integer
+                -   $ref: "#/components/parameters/language-path"
+                -   $ref: "#/components/parameters/format"
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            type: array
+                            items:
+                                anyOf:
+                                    -   $ref: "#/components/schemas/BannerSectionRequest"
+            responses:
+                200:
+                    description: A list of page sections.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/PageSection"
+                        text/xml:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/PageSection"
+    "/v{version}/categories/sections/image":
+        post:
+            tags:
+                - Page Sections
+            description: Uploads an image to be used in a page section.
+            operationId: uploadPageSectionImage
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   $ref: "#/components/parameters/format"
+            requestBody:
+                content:
+                    multipart/form-data:
+                        schema:
+                            type: object
+                            properties:
+                                image:
+                                    type: string
+                                    format: binary
+            responses:
+                "200":
+                    description: The uploaded image's ID.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    imageId:
+                                        type: integer
+                                        description: The unique identifier of the uploaded image.
+                                example:
+                                    imageId: 3594
+                        text/xml:
+                            schema:
+                                type: object
+                                properties:
+                                    imageId:
+                                        type: integer
+                                        description: The unique identifier of the uploaded image.
+                                example:
+                                    imageId: 3594
     "/v{version}/discountcodes":
         get:
             tags:
@@ -3834,7 +3914,7 @@ components:
                     anyOf:
                         -   type: array
                             items:
-                                $ref: "#/components/schemas/PageSectionBanner"
+                                $ref: "#/components/schemas/BannerSectionResponse"
             example:
                 id: 09bf1b84-645e-4f5f-ba68-407f3ee11411
                 type: banner
@@ -3850,7 +3930,53 @@ components:
                             -   url: https://cdn.myonlinestore.com/
                                 width: 1280
                                 height: 720
-        PageSectionBanner:
+        PageSectionImage:
+            properties:
+                url:
+                    description: The URL to the image.
+                    type: string
+                width:
+                    description: The width of the image in pixels.
+                    type: integer
+                height:
+                    description: The height of the image in pixels.
+                    type: integer
+        BannerSectionRequest:
+            properties:
+                type:
+                    description: The type of page section.
+                    type: string
+                position:
+                    description: The position of this page section in the page's section order.
+                    type: integer
+                isEnabled:
+                    description: Determines whether the page section is shown on the storefront.
+                    type: boolean
+                heading:
+                    description: The banner's title.
+                    type: string
+                text:
+                    description: The banner's text.
+                    type: string
+                buttonText:
+                    description: The text in the banner button.
+                    type: string
+                buttonUrl:
+                    description: The target web address of the banner button.
+                    type: string
+                imageId:
+                    description: The unique identifier for the banner background image.
+                    type: integer
+            example:
+                type: banner
+                position: 1
+                isEnabled: true
+                heading: Roger Bannister
+                text: Just because they say it's impossible doesn't mean you can't do it.
+                buttonText: Run
+                buttonUrl: https://en.wikipedia.org/wiki/Roger_Bannister
+                imageId: 3594
+        BannerSectionResponse:
             properties:
                 heading:
                     description: The banner's title.
@@ -3866,23 +3992,12 @@ components:
                     type: string
                 imageId:
                     description: The unique identifier for the banner background image.
-                    type: string
+                    type: integer
                 images:
                     description: A list of images associated with the banner.
                     type: array
                     items:
                         $ref: "#/components/schemas/PageSectionImage"
-        PageSectionImage:
-            properties:
-                url:
-                    description: The URL to the image.
-                    type: string
-                width:
-                    description: The width of the image in pixels.
-                    type: integer
-                height:
-                    description: The height of the image in pixels.
-                    type: integer
         PaymentGateway:
             description: Payment Gateway
             properties:

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -103,7 +103,7 @@ paths:
             operationId: getArticles
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   $ref: "#/components/parameters/limit"
                 -   $ref: "#/components/parameters/offset"
@@ -135,7 +135,7 @@ paths:
             operationId: postArticle
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
             requestBody:
                 content:
@@ -163,7 +163,7 @@ paths:
             operationId: getArticle
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   $ref: "#/components/parameters/use_url_id"
                 -   name: article_id
@@ -190,7 +190,7 @@ paths:
             operationId: deleteArticle
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/use_url_id"
                 -   name: article_id
                     in: path
@@ -216,7 +216,7 @@ paths:
             operationId: patchArticle
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   $ref: "#/components/parameters/use_url_id"
                 -   name: article_id
@@ -251,7 +251,7 @@ paths:
             operationId: postUploadImage
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   name: article_id
                     in: path
@@ -285,7 +285,7 @@ paths:
             operationId: deleteImage
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   name: image_id
                     in: path
@@ -305,7 +305,7 @@ paths:
             operationId: getArticleCount
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   $ref: "#/components/parameters/created_start_date"
                 -   $ref: "#/components/parameters/created_end_date"
@@ -330,7 +330,7 @@ paths:
             operationId: postArticleFields
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   $ref: "#/components/parameters/use_url_id"
                 -   name: article_id
@@ -375,7 +375,7 @@ paths:
             operationId: deleteArticleFields
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   $ref: "#/components/parameters/use_url_id"
                 -   name: article_id
@@ -419,7 +419,7 @@ paths:
             operationId: postArticleListOptions
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   name: articlelist_id
                     in: path
@@ -454,7 +454,7 @@ paths:
             operationId: deleteArticleListOptions
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   name: articlelist_id
                     in: path
@@ -490,7 +490,7 @@ paths:
             operationId: getArticleList
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   name: id
                     in: path
@@ -516,7 +516,7 @@ paths:
             operationId: postArticleLists
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   $ref: "#/components/parameters/use_url_id"
                 -   name: id
@@ -545,7 +545,7 @@ paths:
             operationId: deleteArticleLists
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   $ref: "#/components/parameters/use_url_id"
                 -   name: id
@@ -814,7 +814,7 @@ paths:
             operationId: getOrders
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/limit"
                 -   $ref: "#/components/parameters/offset"
                 -   $ref: "#/components/parameters/start_date"
@@ -860,7 +860,7 @@ paths:
             parameters:
                 -   $ref: "#/components/parameters/version"
                 -   $ref: "#/components/parameters/format"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   name: send_customer_notification
                     in: query
                     description: Send an order confirmation to the customer
@@ -917,7 +917,7 @@ paths:
             operationId: getOrderCount
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/start_date"
                 -   $ref: "#/components/parameters/end_date"
                 -   $ref: "#/components/parameters/format"
@@ -945,7 +945,7 @@ paths:
             operationId: getOrder
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   $ref: "#/components/parameters/order_number_path"
             responses:
@@ -966,7 +966,7 @@ paths:
             operationId: patchOrder
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   $ref: "#/components/parameters/order_number_path"
                 -   name: override_minimum
@@ -1016,7 +1016,7 @@ paths:
             operationId: getCategory
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   name: category_id
                     in: path
@@ -1041,7 +1041,7 @@ paths:
             operationId: patchCategory
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   name: category_id
                     in: path
@@ -1074,7 +1074,7 @@ paths:
             operationId: getCategories
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/limit"
                 -   $ref: "#/components/parameters/offset"
                 -   $ref: "#/components/parameters/format"
@@ -1119,7 +1119,7 @@ paths:
             operationId: postCategory
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
             requestBody:
                 content:
@@ -1146,7 +1146,7 @@ paths:
             operationId: getCategoryArticles
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   $ref: "#/components/parameters/limit"
                 -   $ref: "#/components/parameters/offset"
@@ -1174,7 +1174,7 @@ paths:
             operationId: getCategoryCount
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   $ref: "#/components/parameters/created_start_date"
                 -   $ref: "#/components/parameters/created_end_date"
@@ -1190,6 +1190,36 @@ paths:
                         text/xml:
                             schema:
                                 $ref: "#/components/schemas/CountResponse"
+    "/v{version}/categories/{category_id}/sections/{language}":
+        get:
+            tags:
+                - Page Sections
+            description: Returns all sections related to a page.
+            operationId: getPageSections
+            parameters:
+                -   $ref: "#/components/parameters/version"
+                -   name: category_id
+                    in: path
+                    description: The page's unique ID.
+                    required: true
+                    schema:
+                        type: integer
+                -   $ref: "#/components/parameters/language-path"
+                -   $ref: "#/components/parameters/format"
+            responses:
+                "200":
+                    description: A list of page sections.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/PageSection"
+                        text/xml:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/PageSection"
     "/v{version}/discountcodes":
         get:
             tags:
@@ -1344,7 +1374,7 @@ paths:
             operationId: getNewsletterSubscribers
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   $ref: "#/components/parameters/limit"
                 -   $ref: "#/components/parameters/offset"
@@ -1374,7 +1404,7 @@ paths:
             operationId: postNewsletterSubscriber
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   $ref: "#/components/parameters/activate"
             requestBody:
@@ -1402,7 +1432,7 @@ paths:
             operationId: getNewsletterSubscriber
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   name: email
                     in: path
@@ -1427,7 +1457,7 @@ paths:
             operationId: deleteNewsletterSubscriber
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   name: email
                     in: path
@@ -1452,7 +1482,7 @@ paths:
             operationId: patchNewsletterSubscriber
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   $ref: "#/components/parameters/activate"
                 -   name: email
@@ -1486,7 +1516,7 @@ paths:
             operationId: countNewsletterSubscribers
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
                 -   $ref: "#/components/parameters/activated"
                 -   $ref: "#/components/parameters/created_start_date"
@@ -1567,7 +1597,7 @@ paths:
             parameters:
                 -   $ref: "#/components/parameters/version"
                 -   $ref: "#/components/parameters/format"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   name: mutate_stock
                     in: query
                     description: Perform stock mutations, reverting (specified) mutations of the
@@ -1706,7 +1736,7 @@ paths:
                       [ ]
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
             responses:
                 "200":
@@ -1733,7 +1763,7 @@ paths:
                       [ ]
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
             responses:
                 "200":
@@ -1751,7 +1781,7 @@ paths:
             parameters:
                 -   $ref: "#/components/parameters/version"
                 -   $ref: "#/components/parameters/store"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
             responses:
                 "200":
@@ -1828,7 +1858,7 @@ paths:
             operationId: getStore
             parameters:
                 -   $ref: "#/components/parameters/version"
-                -   $ref: "#/components/parameters/language"
+                -   $ref: "#/components/parameters/language-query"
                 -   $ref: "#/components/parameters/format"
             responses:
                 "200":
@@ -1859,6 +1889,8 @@ tags:
         description: Subscriber details for the store's newsletter
     -   name: Categories (Pages)
         description: Page details
+    -   name: Page Sections
+        description: The building blocks that make up a page's content.
     -   name: Customers
         description: |
             Store customer accounts.
@@ -1975,11 +2007,33 @@ components:
             schema:
                 type: string
                 pattern: '^[A-Z]{2}$'
-        language:
+        language-query:
             name: language
             in: query
-            description: Shop language to return content for
+            description: Store language to return content for.
             required: false
+            schema:
+                type: string
+                enum:
+                    - nl_NL
+                    - en_GB
+                    - de_DE
+                    - fr_FR
+                    - es_ES
+                    - en_US
+                    - pt_PT
+                    - it_IT
+                    - da_DK
+                    - sv_SE
+                    - no_NO
+                    - tr_TR
+                    - pl_PL
+                default: nl_NL
+        language-path:
+            name: language
+            in: path
+            description: Store language to return content for.
+            required: true
             schema:
                 type: string
                 enum:
@@ -3759,6 +3813,76 @@ components:
                         methods:
                             -   name: ideal
                                 displayName: iDEAL
+        PageSection:
+            properties:
+                id:
+                    description: The page section's unique identifier.
+                    type: string
+                    format: uuid
+                type:
+                    description: The type of page section.
+                    type: string
+                    enum:
+                        - banner
+                position:
+                    description: The position of this page section in the page's section order.
+                    type: integer
+                isEnabled:
+                    description: Determines whether the page section is shown on the storefront.
+                    type: boolean
+                content:
+                    anyOf:
+                        -   type: array
+                            items:
+                                $ref: "#/components/schemas/PageSectionBanner"
+            example:
+                id: 09bf1b84-645e-4f5f-ba68-407f3ee11411
+                type: banner
+                position: 1
+                isEnabled: true
+                content:
+                    -   heading: Roger Bannister
+                        text: Just because they say it's impossible doesn't mean you can't do it.
+                        buttonText: Run
+                        buttonUrl: https://en.wikipedia.org/wiki/Roger_Bannister
+                        imageId: 3594
+                        images:
+                            -   url: https://cdn.myonlinestore.com/
+                                width: 1280
+                                height: 720
+        PageSectionBanner:
+            properties:
+                heading:
+                    description: The banner's title.
+                    type: string
+                text:
+                    description: The banner's text.
+                    type: string
+                buttonText:
+                    description: The text in the banner button.
+                    type: string
+                buttonUrl:
+                    description: The target web address of the banner button.
+                    type: string
+                imageId:
+                    description: The unique identifier for the banner background image.
+                    type: string
+                images:
+                    description: A list of images associated with the banner.
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/PageSectionImage"
+        PageSectionImage:
+            properties:
+                url:
+                    description: The URL to the image.
+                    type: string
+                width:
+                    description: The width of the image in pixels.
+                    type: integer
+                height:
+                    description: The height of the image in pixels.
+                    type: integer
         PaymentGateway:
             description: Payment Gateway
             properties:


### PR DESCRIPTION
## ⚠️ Prerequisites
- [x] https://github.com/MyOnlineStore/myonlinestore/pull/11808

## 🌟 Summary.
This pull request adds documentation for three new requests related to the creation of page sections.

## 📝 Changelog.
- Added `GET` request for retrieving page sections.
- Added `PUT` request for creating and updating page sections.
- Added `POST` request for uploading page section images.
- Renamed `language` parameter to `language-query`.
- Added `language-path` parameter.
- Added `PageSection`, `PageSectionImage`, `BannerSectionRequest`, and `BannerSectionResponse` schemas.