### PR TITLE
chore(MOS-2145): Updated github action to use ubuntu latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     deploy:
         name: Test
 
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
 
         steps:
             -   uses: actions/checkout@v2

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,7 +9,7 @@ jobs:
     deploy:
         name: Deploy
 
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
 
         steps:
             -   uses: actions/checkout@v2


### PR DESCRIPTION
This pull request includes updates to the CI and deployment workflows to use the latest version of Ubuntu.

Changes to workflows:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL9-R9): Updated the `runs-on` parameter to use `ubuntu-latest` instead of `ubuntu-20.04`.
* [`.github/workflows/deploy.yaml`](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L12-R12): Updated the `runs-on` parameter to use `ubuntu-latest` instead of `ubuntu-20.04`.